### PR TITLE
feat: add Google ADK beta cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Integration examples for AI observability and evaluation with HoneyHive.
 
 | Cookbook | Description |
 |----------|-------------|
+| [google-adk-cookbook](./google-adk-cookbook) | Multi-agent customer support example with Google ADK, HoneyHive tracing, and evaluation |
 | [wealth-management-agent](./wealth-management-agent) | Multi-agent wealth advisory platform with HoneyHive tracing (CrewAI) |
 
 ### RAG & Vector Databases

--- a/google-adk-cookbook/.gitignore
+++ b/google-adk-cookbook/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.venv/

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -1,0 +1,110 @@
+# Google ADK Multi-Agent Cookbook
+
+This cookbook currently targets the HoneyHive beta SDK release line.
+
+End-to-end example: build a multi-agent customer support bot with [Google ADK](https://google.github.io/adk-docs/) and add observability plus evaluation with [HoneyHive](https://honeyhive.ai).
+
+## What's in here
+
+| File | What it does |
+|------|-------------|
+| `main.py` | Runs a coordinator agent plus billing and technical specialists with HoneyHive tracing |
+| `evaluate.py` | Runs the same agent against a small dataset and scores outputs with HoneyHive experiments |
+| `requirements.txt` | Python dependencies for the cookbook |
+
+## Architecture
+
+A coordinator agent routes customer queries to two specialists:
+
+```text
+Customer Query
+      |
+  [coordinator]
+      |
+  +---+---+
+  |       |
+billing  technical
+agent    agent
+  |       |
+lookup   search
+billing  knowledge_base
+```
+
+The coordinator uses ADK's native `sub_agents` delegation. The model decides which specialist to call based on each agent's description and instructions.
+
+## Setup
+
+Prerequisites:
+
+- Python 3.11+
+- A HoneyHive account
+- A Google AI API key
+- An OpenAI API key for `evaluate.py`
+
+1. Clone the repo and enter this directory:
+
+```bash
+git clone https://github.com/honeyhiveai/cookbook.git
+cd cookbook/google-adk-cookbook
+```
+
+2. Create a virtual environment and install dependencies:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+This installs the latest available HoneyHive beta SDK together with the other cookbook dependencies.
+
+3. Create a `.env` file:
+
+```bash
+HH_API_KEY=your-honeyhive-api-key
+HH_PROJECT=your-project-name
+HH_API_URL=https://api.honeyhive.ai  # optional, override for non-production environments
+GOOGLE_API_KEY=your-google-ai-api-key
+OPENAI_API_KEY=your-openai-key
+```
+
+## Run
+
+### Tracing demo
+
+```bash
+uv run python main.py
+```
+
+This sends three customer queries through the multi-agent system. In HoneyHive, you'll see:
+
+- Coordinator routing decisions
+- Sub-agent delegation and tool calls
+- Session enrichment with business context
+- Custom spans for customer context loading
+
+### Evaluation
+
+```bash
+uv run python evaluate.py
+```
+
+This runs eight test queries through the agent and evaluates:
+
+- `response_quality`: LLM-as-judge scoring for helpfulness, accuracy, and tone
+- `correct_routing`: LLM-as-judge verification that the right specialist handled the query
+
+## What HoneyHive adds
+
+| Capability | Code | Value |
+|-----------|------|-------|
+| Auto-tracing | `HoneyHiveTracer.init()` + `GoogleADKInstrumentor()` | Captures agent runs, model calls, and tool calls automatically |
+| Enrichment | `tracer.enrich_session(...)` | Adds user, plan, and environment metadata to traces |
+| Custom spans | `@trace()` on `load_customer_context()` | Captures your own business logic alongside framework spans |
+| Evaluation | `evaluate()` | Measures quality over a repeatable dataset |
+
+## Resources
+
+- [HoneyHive Docs](https://docs.honeyhive.ai)
+- [Google ADK Docs](https://google.github.io/adk-docs/)
+- [ADK Multi-Agent Systems](https://google.github.io/adk-docs/agents/multi-agents/)

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -56,7 +56,7 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
-This installs the latest available HoneyHive beta SDK together with the other cookbook dependencies.
+This keeps the cookbook on the HoneyHive beta SDK release line while installing the other dependencies.
 
 3. Create a `.env` file:
 
@@ -92,7 +92,7 @@ uv run python evaluate.py
 This runs eight test queries through the agent and evaluates:
 
 - `response_quality`: LLM-as-judge scoring for helpfulness, accuracy, and tone
-- `correct_routing`: LLM-as-judge verification that the right specialist handled the query
+- `correct_routing`: exact verification that ADK delegated to the expected specialist based on observed event authors
 
 ## What HoneyHive adds
 

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -114,7 +114,7 @@ In HoneyHive, open the two runs (`customer-support-eval-v1` and `customer-suppor
 ## Implementation notes
 
 - **`max_llm_calls=15`**: `main.py` caps agent iterations via `RunConfig` so a confused agent fails fast instead of looping through many tool-call retries. When the v1 agent exhausts the cap it returns a clear `[agent gave up: ...]` response that the judge correctly scores as 0.
-- **HoneyHive summary fetch**: the current HoneyHive SDK has a pydantic parsing bug when returning the final run summary. The experiment data itself uploads correctly, so `evaluate.py` catches the `ValidationError` and directs you to the HoneyHive UI for the scores.
+- **HoneyHive summary fetch**: on the current pre-release SDK, the client-side aggregate parse at the end of `evaluate()` can raise a `pydantic.ValidationError`. The run itself uploads successfully, so `evaluate.py` catches the error and points you at the HoneyHive UI for the scores. This will go away once we pin a newer SDK release.
 
 ## What HoneyHive adds
 

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -114,7 +114,6 @@ In HoneyHive, open the two runs (`customer-support-eval-v1` and `customer-suppor
 ## Implementation notes
 
 - **`max_llm_calls=15`**: `main.py` caps agent iterations via `RunConfig` so a confused agent fails fast instead of looping through many tool-call retries. When the v1 agent exhausts the cap it returns a clear `[agent gave up: ...]` response that the judge correctly scores as 0.
-- **HoneyHive summary fetch**: on the current pre-release SDK, the client-side aggregate parse at the end of `evaluate()` can raise a `pydantic.ValidationError`. The run itself uploads successfully, so `evaluate.py` catches the error and points you at the HoneyHive UI for the scores. This will go away once we pin a newer SDK release.
 
 ## What HoneyHive adds
 

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -2,19 +2,22 @@
 
 This cookbook currently targets the HoneyHive beta SDK release line.
 
-It is currently configured to run Google ADK with OpenAI models through LiteLLM.
+End-to-end example: build a multi-agent customer support bot with [Google ADK](https://google.github.io/adk-docs/), add observability with [HoneyHive](https://honeyhive.ai), and use an evaluation run to catch a quality regression.
 
-End-to-end example: build a multi-agent customer support bot with [Google ADK](https://google.github.io/adk-docs/) and add observability plus evaluation with [HoneyHive](https://honeyhive.ai).
+The cookbook ships two versions of the same agent so you can see the before/after side by side in HoneyHive:
+
+- `agent_v1.py` — initial agent with vague tool docstrings and minimal instructions. The agent has to guess internal enum codes and often fails.
+- `agent_v2.py` — improved agent. Same tools, same enum codes, but with detailed docstrings and clearer delegation rules. The agent routes and calls tools correctly.
 
 ## What's in here
 
-
 | File               | What it does                                                                              |
 | ------------------ | ----------------------------------------------------------------------------------------- |
-| `main.py`          | Runs a coordinator agent plus billing and technical specialists with HoneyHive tracing    |
-| `evaluate.py`      | Runs the same agent against a small dataset and scores outputs with HoneyHive experiments |
-| `requirements.txt` | Python dependencies for the cookbook                                                      |
-
+| `main.py`          | Thin runner: loads the selected agent version and sends one query with HoneyHive tracing  |
+| `evaluate.py`      | Runs the selected agent across a 5-query dataset and scores responses with an LLM judge    |
+| `agent_v1.py`      | Initial (degraded) agent used as the "before" baseline                                     |
+| `agent_v2.py`      | Improved agent used as the "after" comparison                                              |
+| `requirements.txt` | Python dependencies for the cookbook                                                       |
 
 ## Architecture
 
@@ -42,7 +45,7 @@ Prerequisites:
 
 - Python 3.11+
 - A HoneyHive account
-- An OpenAI API key
+- A Google Gemini API key
 
 1. Clone the repo and enter this directory:
 
@@ -51,7 +54,7 @@ git clone https://github.com/honeyhiveai/cookbook.git
 cd cookbook/google-adk-cookbook
 ```
 
-1. Create a virtual environment and install dependencies:
+2. Create a virtual environment and install dependencies:
 
 ```bash
 uv venv
@@ -59,47 +62,61 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
-This keeps the cookbook on the HoneyHive beta SDK release line while installing the other dependencies.
-
-The current setup uses LiteLLM so ADK can call OpenAI models with your existing `OPENAI_API_KEY`.
-
-1. Create a `.env` file:
+3. Create a `.env` file:
 
 ```bash
 HH_API_KEY=your-honeyhive-api-key
 HH_PROJECT=your-project-name
 HH_API_URL=https://api.honeyhive.ai  # optional, override for non-production environments
-OPENAI_API_KEY=your-openai-key
+GOOGLE_API_KEY=your-gemini-api-key
 ```
 
 ## Run
 
 ### Tracing demo
 
+Run the degraded agent once and inspect its trace in HoneyHive:
+
 ```bash
-uv run python main.py
+uv run python main.py --version v1
 ```
 
-This sends one customer query through the multi-agent system. In HoneyHive, you'll see:
+Then run the improved agent:
 
-- Coordinator routing decisions
-- Sub-agent delegation and tool calls
-- Session enrichment with business context
-- Custom spans for customer context loading
+```bash
+uv run python main.py --version v2
+```
+
+For the same query ("I was charged $24.50 but I thought that was refunded?") you should see:
+
+- **v1**: the agent fails to call `lookup_billing` with the right enum, apologizes, and asks the customer for a transaction ID.
+- **v2**: the agent delegates to `billing_agent`, calls `lookup_billing` with `query_type="BIL_RMA_03"`, and returns the refund ID and status.
+
+Both runs show up in HoneyHive with the same spans and `agent_version` metadata so you can compare them directly.
 
 ### Evaluation
 
+Run the evaluation for each version:
+
 ```bash
-uv run python evaluate.py
+uv run python evaluate.py --version v1
+uv run python evaluate.py --version v2
 ```
 
-This runs four test queries through the agent and evaluates:
+Each run sends 5 queries through the agent and scores each response with an LLM-as-judge (`response_quality`) on a strict 3-point scale:
 
-- `response_quality`: LLM-as-judge scoring for helpfulness, accuracy, and tone
-- `correct_routing`: exact verification that ADK delegated to the expected specialist based on observed event authors
+- `1` – fully helpful (concrete amounts, dates, article IDs, or troubleshooting steps)
+- `0.5` – partially helpful (addresses the question but vague or incomplete)
+- `0` – unhelpful (apologizes, admits a tool error, or dodges the question)
+
+In HoneyHive, open the two runs (`customer-support-eval-v1` and `customer-support-eval-v2`) and compare the `response_quality` aggregate. v2 typically scores near 1.0 while v1 scores well below that.
+
+## Implementation notes
+
+- **`max_llm_calls=15`**: `main.py` caps agent iterations via `RunConfig` so a confused agent fails fast instead of looping through many tool-call retries. When the v1 agent exhausts the cap it returns a clear `[agent gave up: ...]` response that the judge correctly scores as 0.
+- **HoneyHive summary fetch**: the current HoneyHive SDK has a pydantic parsing bug when returning the final run summary. The experiment data itself uploads correctly, so `evaluate.py` catches the `ValidationError` and directs you to the HoneyHive UI for the scores.
 
 ## What HoneyHive adds
-
 
 | Capability   | Code                                                 | Value                                                          |
 | ------------ | ---------------------------------------------------- | -------------------------------------------------------------- |
@@ -108,10 +125,8 @@ This runs four test queries through the agent and evaluates:
 | Custom spans | `@trace()` on `load_customer_context()`              | Captures your own business logic alongside framework spans     |
 | Evaluation   | `evaluate()`                                         | Measures quality over a repeatable dataset                     |
 
-
 ## Resources
 
 - [HoneyHive Docs](https://docs.honeyhive.ai)
 - [Google ADK Docs](https://google.github.io/adk-docs/)
 - [ADK Multi-Agent Systems](https://google.github.io/adk-docs/agents/multi-agents/)
-

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -8,11 +8,13 @@ End-to-end example: build a multi-agent customer support bot with [Google ADK](h
 
 ## What's in here
 
-| File | What it does |
-|------|-------------|
-| `main.py` | Runs a coordinator agent plus billing and technical specialists with HoneyHive tracing |
-| `evaluate.py` | Runs the same agent against a small dataset and scores outputs with HoneyHive experiments |
-| `requirements.txt` | Python dependencies for the cookbook |
+
+| File               | What it does                                                                              |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| `main.py`          | Runs a coordinator agent plus billing and technical specialists with HoneyHive tracing    |
+| `evaluate.py`      | Runs the same agent against a small dataset and scores outputs with HoneyHive experiments |
+| `requirements.txt` | Python dependencies for the cookbook                                                      |
+
 
 ## Architecture
 
@@ -49,7 +51,7 @@ git clone https://github.com/honeyhiveai/cookbook.git
 cd cookbook/google-adk-cookbook
 ```
 
-2. Create a virtual environment and install dependencies:
+1. Create a virtual environment and install dependencies:
 
 ```bash
 uv venv
@@ -61,7 +63,7 @@ This keeps the cookbook on the HoneyHive beta SDK release line while installing 
 
 The current setup uses LiteLLM so ADK can call OpenAI models with your existing `OPENAI_API_KEY`.
 
-3. Create a `.env` file:
+1. Create a `.env` file:
 
 ```bash
 HH_API_KEY=your-honeyhive-api-key
@@ -78,7 +80,7 @@ OPENAI_API_KEY=your-openai-key
 uv run python main.py
 ```
 
-This sends three customer queries through the multi-agent system. In HoneyHive, you'll see:
+This sends one customer query through the multi-agent system. In HoneyHive, you'll see:
 
 - Coordinator routing decisions
 - Sub-agent delegation and tool calls
@@ -91,22 +93,25 @@ This sends three customer queries through the multi-agent system. In HoneyHive, 
 uv run python evaluate.py
 ```
 
-This runs eight test queries through the agent and evaluates:
+This runs four test queries through the agent and evaluates:
 
 - `response_quality`: LLM-as-judge scoring for helpfulness, accuracy, and tone
 - `correct_routing`: exact verification that ADK delegated to the expected specialist based on observed event authors
 
 ## What HoneyHive adds
 
-| Capability | Code | Value |
-|-----------|------|-------|
+
+| Capability   | Code                                                 | Value                                                          |
+| ------------ | ---------------------------------------------------- | -------------------------------------------------------------- |
 | Auto-tracing | `HoneyHiveTracer.init()` + `GoogleADKInstrumentor()` | Captures agent runs, model calls, and tool calls automatically |
-| Enrichment | `tracer.enrich_session(...)` | Adds user, plan, and environment metadata to traces |
-| Custom spans | `@trace()` on `load_customer_context()` | Captures your own business logic alongside framework spans |
-| Evaluation | `evaluate()` | Measures quality over a repeatable dataset |
+| Enrichment   | `tracer.enrich_session(...)`                         | Adds user, plan, and environment metadata to traces            |
+| Custom spans | `@trace()` on `load_customer_context()`              | Captures your own business logic alongside framework spans     |
+| Evaluation   | `evaluate()`                                         | Measures quality over a repeatable dataset                     |
+
 
 ## Resources
 
 - [HoneyHive Docs](https://docs.honeyhive.ai)
 - [Google ADK Docs](https://google.github.io/adk-docs/)
 - [ADK Multi-Agent Systems](https://google.github.io/adk-docs/agents/multi-agents/)
+

--- a/google-adk-cookbook/README.md
+++ b/google-adk-cookbook/README.md
@@ -2,6 +2,8 @@
 
 This cookbook currently targets the HoneyHive beta SDK release line.
 
+It is currently configured to run Google ADK with OpenAI models through LiteLLM.
+
 End-to-end example: build a multi-agent customer support bot with [Google ADK](https://google.github.io/adk-docs/) and add observability plus evaluation with [HoneyHive](https://honeyhive.ai).
 
 ## What's in here
@@ -38,8 +40,7 @@ Prerequisites:
 
 - Python 3.11+
 - A HoneyHive account
-- A Google AI API key
-- An OpenAI API key for `evaluate.py`
+- An OpenAI API key
 
 1. Clone the repo and enter this directory:
 
@@ -58,13 +59,14 @@ uv pip install -r requirements.txt
 
 This keeps the cookbook on the HoneyHive beta SDK release line while installing the other dependencies.
 
+The current setup uses LiteLLM so ADK can call OpenAI models with your existing `OPENAI_API_KEY`.
+
 3. Create a `.env` file:
 
 ```bash
 HH_API_KEY=your-honeyhive-api-key
 HH_PROJECT=your-project-name
 HH_API_URL=https://api.honeyhive.ai  # optional, override for non-production environments
-GOOGLE_API_KEY=your-google-ai-api-key
 OPENAI_API_KEY=your-openai-key
 ```
 

--- a/google-adk-cookbook/agent_v1.py
+++ b/google-adk-cookbook/agent_v1.py
@@ -1,0 +1,66 @@
+"""
+Initial (v1) customer support agent.
+
+This version ships with vague tool docstrings and minimal agent instructions.
+The underlying billing and KB APIs use opaque internal enum codes
+(`BIL_ACCT_01`, `KB_EXP_DATA`, ...) but the tool docstrings do not document
+them, so the model has to guess the right enum value from the query. This
+is the "before" state we evaluate to measure improvement in `agent_v2.py`.
+"""
+
+from google.adk.agents import LlmAgent
+
+MODEL = "gemini-flash-latest"
+
+
+def lookup_billing(customer_id: str, query_type: str) -> dict:
+    """Look up billing info."""
+    if query_type == "BIL_ACCT_01":
+        return {"customer_id": customer_id, "balance": "$1,247.50", "due": "2026-03-01"}
+    if query_type == "BIL_TXN_02":
+        return {
+            "customer_id": customer_id,
+            "recent_charges": [
+                {"date": "2026-02-01", "amount": "$99.00", "description": "Monthly subscription"},
+                {"date": "2026-02-05", "amount": "$24.50", "description": "API overage"},
+            ],
+        }
+    if query_type == "BIL_RMA_03":
+        return {"customer_id": customer_id, "refund_id": "REF-2026-0142", "amount": "$24.50", "status": "processing"}
+    return {"error": f"Unknown query_type {query_type!r}."}
+
+
+def search_knowledge_base(category: str) -> dict:
+    """Search the KB."""
+    if category == "KB_EXP_DATA":
+        return {"article_id": "KB-1042", "solution": "Clear browser cache and retry. Free-plan exports are capped at 10k rows."}
+    if category == "KB_API_LIM":
+        return {"article_id": "KB-0891", "solution": "Default rate limit is 100 req/min. Enterprise gets 1000 req/min."}
+    if category == "KB_AUTH_SSO":
+        return {"article_id": "KB-0567", "solution": "Reset at /reset-password. For SSO, check Settings > SSO."}
+    return {"article_id": "KB-0001", "solution": "Please provide more details."}
+
+
+def build_agents() -> LlmAgent:
+    """Build the multi-agent customer support system."""
+    billing_agent = LlmAgent(
+        name="billing_agent",
+        model=MODEL,
+        description="Billing.",
+        instruction="Help with billing. Use tools if useful.",
+        tools=[lookup_billing],
+    )
+    technical_agent = LlmAgent(
+        name="technical_agent",
+        model=MODEL,
+        description="Tech.",
+        instruction="Help with technical issues. Use tools if useful.",
+        tools=[search_knowledge_base],
+    )
+    return LlmAgent(
+        name="customer_support",
+        model=MODEL,
+        description="Customer support.",
+        instruction="Answer the customer.",
+        sub_agents=[billing_agent, technical_agent],
+    )

--- a/google-adk-cookbook/agent_v2.py
+++ b/google-adk-cookbook/agent_v2.py
@@ -1,0 +1,103 @@
+"""
+Improved (v2) customer support agent.
+
+Same tool implementations and opaque enum codes as `agent_v1.py`, but with:
+  - Detailed tool docstrings that document every enum value.
+  - Descriptive sub-agent descriptions so the coordinator routes correctly.
+  - An explicit delegation rule in the coordinator's instruction.
+
+Nothing about the code logic changed. Every improvement is in what the model
+sees about the tools and agents. This is the "after" state.
+"""
+
+from google.adk.agents import LlmAgent
+
+MODEL = "gemini-flash-latest"
+
+
+def lookup_billing(customer_id: str, query_type: str) -> dict:
+    """Look up billing information for a customer.
+
+    Args:
+        customer_id: The internal user id of the customer (e.g. "customer_42").
+        query_type: One of:
+            - "BIL_ACCT_01": current account balance and due date
+            - "BIL_TXN_02": recent charges on the account
+            - "BIL_RMA_03": status of an in-flight refund
+
+    Returns:
+        A dict with the requested billing fields, or {"error": ...} if
+        query_type is not one of the supported enum codes above.
+    """
+    if query_type == "BIL_ACCT_01":
+        return {"customer_id": customer_id, "balance": "$1,247.50", "due": "2026-03-01"}
+    if query_type == "BIL_TXN_02":
+        return {
+            "customer_id": customer_id,
+            "recent_charges": [
+                {"date": "2026-02-01", "amount": "$99.00", "description": "Monthly subscription"},
+                {"date": "2026-02-05", "amount": "$24.50", "description": "API overage"},
+            ],
+        }
+    if query_type == "BIL_RMA_03":
+        return {"customer_id": customer_id, "refund_id": "REF-2026-0142", "amount": "$24.50", "status": "processing"}
+    return {"error": f"Unknown query_type {query_type!r}."}
+
+
+def search_knowledge_base(category: str) -> dict:
+    """Search the technical knowledge base for a solution.
+
+    Args:
+        category: One of:
+            - "KB_EXP_DATA": data export errors, CSV/JSON export failures, row limits
+            - "KB_API_LIM": API rate limits, throttling, quota questions
+            - "KB_AUTH_SSO": login, password reset, SSO / SAML setup
+
+    Returns:
+        A dict with `article_id` and `solution`. Falls back to a generic
+        "please provide more details" article if category is not recognized.
+    """
+    if category == "KB_EXP_DATA":
+        return {"article_id": "KB-1042", "solution": "Clear browser cache and retry. Free-plan exports are capped at 10k rows."}
+    if category == "KB_API_LIM":
+        return {"article_id": "KB-0891", "solution": "Default rate limit is 100 req/min. Enterprise gets 1000 req/min."}
+    if category == "KB_AUTH_SSO":
+        return {"article_id": "KB-0567", "solution": "Reset at /reset-password. For SSO, check Settings > SSO."}
+    return {"article_id": "KB-0001", "solution": "Please provide more details."}
+
+
+def build_agents() -> LlmAgent:
+    """Build the multi-agent customer support system."""
+    billing_agent = LlmAgent(
+        name="billing_agent",
+        model=MODEL,
+        description="Handles billing questions: balances, charges, refund status.",
+        instruction=(
+            "You are a billing support specialist. "
+            "Use lookup_billing to answer the customer. "
+            "Summarize the result with amounts, dates, and the next step."
+        ),
+        tools=[lookup_billing],
+    )
+    technical_agent = LlmAgent(
+        name="technical_agent",
+        model=MODEL,
+        description="Handles product bugs, API questions, login/SSO, and troubleshooting.",
+        instruction=(
+            "You are a technical support specialist. "
+            "Use search_knowledge_base for bugs, exports, login, SSO, and API questions. "
+            "Respond with concrete troubleshooting steps."
+        ),
+        tools=[search_knowledge_base],
+    )
+    return LlmAgent(
+        name="customer_support",
+        model=MODEL,
+        description="Routes customer support requests to the right specialist.",
+        instruction=(
+            "You are the front-line customer support coordinator. "
+            "Delegate billing issues to billing_agent; product, login, export, SSO, and API issues to technical_agent. "
+            "Do not answer specialist questions yourself - always delegate first, then return a concise final response."
+        ),
+        sub_agents=[billing_agent, technical_agent],
+    )

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -16,7 +16,6 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import GenerateContentConfig
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-from pydantic import ValidationError
 
 from honeyhive import evaluate
 
@@ -105,23 +104,16 @@ if __name__ == "__main__":
 
     agent_mod = load_agent_module(args.version)
 
-    try:
-        result = evaluate(
-            function=make_run_support_agent(agent_mod.build_agents),
-            dataset=dataset,
-            evaluators=[response_quality],
-            instrumentors=[
-                lambda: GoogleADKInstrumentor(),
-            ],
-            name=f"customer-support-eval-{args.version}",
-        )
-        run_id = result.run_id
-    except ValidationError:
-        # The run uploads successfully; only the client-side aggregate parse
-        # fails on the current SDK. Scores are visible in the HoneyHive UI.
-        run_id = None
+    result = evaluate(
+        function=make_run_support_agent(agent_mod.build_agents),
+        dataset=dataset,
+        evaluators=[response_quality],
+        instrumentors=[
+            lambda: GoogleADKInstrumentor(),
+        ],
+        name=f"customer-support-eval-{args.version}",
+    )
 
     print(f"Version:   {args.version}")
-    if run_id:
-        print(f"Run ID:    {run_id}")
+    print(f"Run ID:    {result.run_id}")
     print("View aggregate scores and traces in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -16,6 +16,7 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import GenerateContentConfig
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+from pydantic import ValidationError
 
 from honeyhive import evaluate
 
@@ -104,16 +105,22 @@ if __name__ == "__main__":
 
     agent_mod = load_agent_module(args.version)
 
-    result = evaluate(
-        function=make_run_support_agent(agent_mod.build_agents),
-        dataset=dataset,
-        evaluators=[response_quality],
-        instrumentors=[
-            lambda: GoogleADKInstrumentor(),
-        ],
-        name=f"customer-support-eval-{args.version}",
-    )
+    run_id = None
+    try:
+        result = evaluate(
+            function=make_run_support_agent(agent_mod.build_agents),
+            dataset=dataset,
+            evaluators=[response_quality],
+            instrumentors=[
+                lambda: GoogleADKInstrumentor(),
+            ],
+            name=f"customer-support-eval-{args.version}",
+        )
+        run_id = result.run_id
+    except ValidationError:
+        pass
 
     print(f"Version:   {args.version}")
-    print(f"Run ID:    {result.run_id}")
+    if run_id:
+        print(f"Run ID:    {run_id}")
     print("View aggregate scores and traces in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -117,14 +117,11 @@ if __name__ == "__main__":
         )
         run_id = result.run_id
     except ValidationError:
-        # Experiment runs + uploads fine; a pre-existing HoneyHive SDK bug
-        # crashes only when parsing the final summary response. Scores are
-        # still available in the HoneyHive UI.
+        # The run uploads successfully; only the client-side aggregate parse
+        # fails on the current SDK. Scores are visible in the HoneyHive UI.
         run_id = None
 
     print(f"Version:   {args.version}")
     if run_id:
         print(f"Run ID:    {run_id}")
-    else:
-        print("Run completed (summary fetch failed due to an SDK bug).")
-    print("View results in HoneyHive: https://app.honeyhive.ai")
+    print("View aggregate scores and traces in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -118,9 +118,7 @@ if __name__ == "__main__":
         )
         run_id = result.run_id
     except ValidationError:
-        # The current pre-release SDK mistypes the run-summary response,
-        # so the final aggregate parse raises after the run has already
-        # uploaded. Remove this once the pinned SDK version is bumped.
+        # Works around a minor bug in honeyhive rc21; safe to remove later.
         pass
 
     print(f"Version:   {args.version}")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -11,76 +11,49 @@ import uuid
 from dotenv import load_dotenv
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
-from google.genai.types import Content, Part
 from openai import OpenAI
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 from openinference.instrumentation.openai import OpenAIInstrumentor
 
 from honeyhive import evaluate
 
-from main import APP_NAME, USER_ID, build_agent_input, build_agents
+from main import APP_NAME, USER_ID, build_agents, handle_customer_query
 
 load_dotenv()
 
 openai_client = OpenAI()
 
+ROUTES = {"billing_agent": "billing", "technical_agent": "technical"}
+
 
 def detect_specialist(authors: list[str]) -> str:
     """Infer which specialist handled the request from ADK event authors."""
-    specialists = []
-    for author in authors:
-        if author == "billing_agent":
-            specialists.append("billing")
-        elif author == "technical_agent":
-            specialists.append("technical")
-    unique_specialists = list(dict.fromkeys(specialists))
-
-    if len(unique_specialists) == 1:
-        return unique_specialists[0]
-    if len(unique_specialists) > 1:
-        return "multiple"
-    return "unknown"
+    found = {ROUTES[a] for a in authors if a in ROUTES}
+    if len(found) == 1:
+        return found.pop()
+    return "multiple" if found else "unknown"
 
 
 async def run_support_agent(datapoint: dict) -> dict:
     """Run the support agent on a single datapoint."""
-    query = datapoint["inputs"]["query"].strip()
-
-    coordinator = build_agents()
     session_service = InMemorySessionService()
     session_id = f"eval-{uuid.uuid4().hex[:12]}"
-
     await session_service.create_session(
-        app_name=f"{APP_NAME}-eval",
-        user_id=USER_ID,
-        session_id=session_id,
+        app_name=f"{APP_NAME}-eval", user_id=USER_ID, session_id=session_id
     )
-
     runner = Runner(
-        agent=coordinator,
+        agent=build_agents(),
         app_name=f"{APP_NAME}-eval",
         session_service=session_service,
     )
 
-    agent_input = build_agent_input(query, USER_ID)
-    msg = Content(role="user", parts=[Part(text=agent_input)])
-    response_text = ""
-    event_authors: list[str] = []
-    async for event in runner.run_async(
-        user_id=USER_ID,
-        session_id=session_id,
-        new_message=msg,
-    ):
-        author = getattr(event, "author", None)
-        if isinstance(author, str):
-            event_authors.append(author)
-        if event.is_final_response() and event.content and event.content.parts:
-            response_text = event.content.parts[0].text or ""
-
+    response, authors = await handle_customer_query(
+        runner, session_id, datapoint["inputs"]["query"]
+    )
     return {
-        "response": response_text,
-        "handled_by": detect_specialist(event_authors),
-        "event_authors": event_authors,
+        "response": response,
+        "handled_by": detect_specialist(authors),
+        "event_authors": authors,
     }
 
 
@@ -93,14 +66,7 @@ def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
         messages=[
             {
                 "role": "system",
-                "content": (
-                    "You evaluate customer support responses.\n"
-                    "Score the response from 0.0 to 1.0 based on:\n"
-                    "- whether it answers the question\n"
-                    "- whether it is accurate for the expected category\n"
-                    "- whether the tone is professional and helpful\n\n"
-                    'Respond with JSON of the form {"score": <number between 0.0 and 1.0>}.'
-                ),
+                "content": 'Score customer support responses 0.0-1.0 on accuracy, helpfulness, and tone. Return {"score": <number>}.',
             },
             {
                 "role": "user",
@@ -130,51 +96,18 @@ def correct_routing(outputs: dict, inputs: dict, ground_truth: dict) -> float:
             "Could not determine a single delegated specialist from ADK events. "
             f"Observed authors: {outputs.get('event_authors', [])!r}"
         )
-
     return 1.0 if handled_by == ground_truth["category"] else 0.0
 
 
 dataset = [
-    {
-        "inputs": {"query": "I was charged $24.50 but I thought that was refunded?"},
-        "ground_truth": {"category": "billing"},
-    },
-    {
-        "inputs": {"query": "What's my current account balance?"},
-        "ground_truth": {"category": "billing"},
-    },
-    {
-        "inputs": {"query": "Can you show me my recent charges for this month?"},
-        "ground_truth": {"category": "billing"},
-    },
-    {
-        "inputs": {"query": "The export button gives me error 500."},
-        "ground_truth": {"category": "technical"},
-    },
-    {
-        "inputs": {"query": "I can't log in. The password reset email never arrived."},
-        "ground_truth": {"category": "technical"},
-    },
-    {
-        "inputs": {"query": "Our API calls are getting rate limited. How do we increase the limit?"},
-        "ground_truth": {"category": "technical"},
-    },
-    {
-        "inputs": {"query": "I need a refund for the duplicate charge on Feb 5th."},
-        "ground_truth": {"category": "billing"},
-    },
-    {
-        "inputs": {"query": "How do I export data from the dashboard? It keeps failing."},
-        "ground_truth": {"category": "technical"},
-    },
+    {"inputs": {"query": "I was charged $24.50 but I thought that was refunded?"}, "ground_truth": {"category": "billing"}},
+    {"inputs": {"query": "What's my current account balance?"}, "ground_truth": {"category": "billing"}},
+    {"inputs": {"query": "The export button gives me error 500."}, "ground_truth": {"category": "technical"}},
+    {"inputs": {"query": "Our API calls are getting rate limited. How do we increase the limit?"}, "ground_truth": {"category": "technical"}},
 ]
 
 
 if __name__ == "__main__":
-    print("=" * 60)
-    print("Customer Support Agent - Evaluation")
-    print("=" * 60)
-
     result = evaluate(
         function=run_support_agent,
         dataset=dataset,
@@ -186,6 +119,5 @@ if __name__ == "__main__":
         name="customer-support-eval",
     )
 
-    print(f"\nExperiment run_id: {result.run_id}")
+    print(f"Experiment run_id: {result.run_id}")
     print("View results in HoneyHive: https://app.honeyhive.ai")
-    print("=" * 60)

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -1,123 +1,130 @@
 """
 Evaluate the customer support agent using HoneyHive experiments.
 
-Run:
-    uv run python evaluate.py
+Run either version and compare `response_quality` scores in HoneyHive:
+    uv run python evaluate.py --version v1
+    uv run python evaluate.py --version v2
 """
 
+import argparse
 import json
 import uuid
 
 from dotenv import load_dotenv
+from google import genai
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
-from openai import OpenAI
+from google.genai.types import GenerateContentConfig
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-from openinference.instrumentation.openai import OpenAIInstrumentor
+from pydantic import ValidationError
 
 from honeyhive import evaluate
 
-from main import APP_NAME, USER_ID, build_agents, handle_customer_query
+from main import APP_NAME, USER_ID, handle_customer_query, load_agent_module
 
-load_dotenv()
+load_dotenv(override=True)
 
-openai_client = OpenAI()
-
-ROUTES = {"billing_agent": "billing", "technical_agent": "technical"}
-
-
-def detect_specialist(authors: list[str]) -> str:
-    """Infer which specialist handled the request from ADK event authors."""
-    found = {ROUTES[a] for a in authors if a in ROUTES}
-    if len(found) == 1:
-        return found.pop()
-    return "multiple" if found else "unknown"
+JUDGE_MODEL = "gemini-flash-latest"
+genai_client = genai.Client()
 
 
-async def run_support_agent(datapoint: dict) -> dict:
-    """Run the support agent on a single datapoint."""
-    session_service = InMemorySessionService()
-    session_id = f"eval-{uuid.uuid4().hex[:12]}"
-    await session_service.create_session(
-        app_name=f"{APP_NAME}-eval", user_id=USER_ID, session_id=session_id
+def make_run_support_agent(build_agents):
+    """Build a run_support_agent task bound to a specific agent version."""
+
+    async def run_support_agent(datapoint: dict) -> dict:
+        """Run the support agent on a single datapoint."""
+        session_service = InMemorySessionService()
+        session_id = str(uuid.uuid4())
+        await session_service.create_session(
+            app_name=APP_NAME, user_id=USER_ID, session_id=session_id
+        )
+        runner = Runner(
+            agent=build_agents(),
+            app_name=APP_NAME,
+            session_service=session_service,
+        )
+
+        response = await handle_customer_query(
+            runner, session_id, datapoint["inputs"]["query"]
+        )
+        return {"response": response}
+
+    return run_support_agent
+
+
+JUDGE_SYSTEM = (
+    "You are a strict customer-support QA reviewer. Score the agent's response "
+    "on a 3-point scale:\n"
+    "  1   - Fully helpful. Directly answers the question with concrete specifics "
+    "(amounts, dates, article IDs, troubleshooting steps).\n"
+    "  0.5 - Partially helpful. Addresses the question but is vague, incomplete, "
+    "or missing key specifics.\n"
+    "  0   - Unhelpful. Apologizes, admits a tool error, dodges the question, or "
+    "returns no actionable information.\n"
+    'Return strictly {"score": 0 | 0.5 | 1}.'
+)
+
+
+def response_quality(outputs: dict, inputs: dict) -> float:
+    """Judge whether the response is fully / partially / not helpful."""
+    result = genai_client.models.generate_content(
+        model=JUDGE_MODEL,
+        contents=(
+            f"Customer query: {inputs['query']}\n"
+            f"Agent response: {outputs.get('response', '')}"
+        ),
+        config=GenerateContentConfig(
+            system_instruction=JUDGE_SYSTEM,
+            temperature=0,
+            response_mime_type="application/json",
+        ),
     )
-    runner = Runner(
-        agent=build_agents(),
-        app_name=f"{APP_NAME}-eval",
-        session_service=session_service,
-    )
-
-    response, authors = await handle_customer_query(
-        runner, session_id, datapoint["inputs"]["query"]
-    )
-    return {
-        "response": response,
-        "handled_by": detect_specialist(authors),
-        "event_authors": authors,
-    }
-
-
-def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
-    """Judge whether the response is accurate, helpful, and appropriately toned."""
-    result = openai_client.chat.completions.create(
-        model="gpt-4o-mini",
-        temperature=0,
-        response_format={"type": "json_object"},
-        messages=[
-            {
-                "role": "system",
-                "content": 'Score customer support responses 0.0-1.0 on accuracy, helpfulness, and tone. Return {"score": <number>}.',
-            },
-            {
-                "role": "user",
-                "content": (
-                    f"Customer query: {inputs['query']}\n"
-                    f"Expected category: {ground_truth['category']}\n"
-                    f"Agent response: {outputs.get('response', '')}"
-                ),
-            },
-        ],
-    )
-    raw = result.choices[0].message.content
+    raw = result.text
     if not raw:
         raise ValueError("Judge returned an empty response.")
 
     score = float(json.loads(raw)["score"])
-    if not 0.0 <= score <= 1.0:
-        raise ValueError(f"Judge score must be between 0.0 and 1.0, got {score}.")
+    if score not in {0.0, 0.5, 1.0}:
+        raise ValueError(f"Judge score must be 0, 0.5, or 1, got {score}.")
     return score
 
 
-def correct_routing(outputs: dict, inputs: dict, ground_truth: dict) -> float:
-    """Check whether ADK delegated the query to the expected specialist."""
-    handled_by = outputs.get("handled_by")
-    if handled_by not in {"billing", "technical"}:
-        raise ValueError(
-            "Could not determine a single delegated specialist from ADK events. "
-            f"Observed authors: {outputs.get('event_authors', [])!r}"
-        )
-    return 1.0 if handled_by == ground_truth["category"] else 0.0
-
-
 dataset = [
-    {"inputs": {"query": "I was charged $24.50 but I thought that was refunded?"}, "ground_truth": {"category": "billing"}},
-    {"inputs": {"query": "What's my current account balance?"}, "ground_truth": {"category": "billing"}},
-    {"inputs": {"query": "The export button gives me error 500."}, "ground_truth": {"category": "technical"}},
-    {"inputs": {"query": "Our API calls are getting rate limited. How do we increase the limit?"}, "ground_truth": {"category": "technical"}},
+    {"inputs": {"query": "I was charged $24.50 but I thought that was refunded?"}},
+    {"inputs": {"query": "What's my current account balance?"}},
+    {"inputs": {"query": "Show me my recent charges."}},
+    {"inputs": {"query": "The export button gives me error 500."}},
+    {"inputs": {"query": "Our API calls are getting rate limited. How do we increase the limit?"}},
 ]
 
 
 if __name__ == "__main__":
-    result = evaluate(
-        function=run_support_agent,
-        dataset=dataset,
-        evaluators=[response_quality, correct_routing],
-        instrumentors=[
-            lambda: GoogleADKInstrumentor(),
-            lambda: OpenAIInstrumentor(),
-        ],
-        name="customer-support-eval",
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", choices=["v1", "v2"], default="v2")
+    args = parser.parse_args()
 
-    print(f"Experiment run_id: {result.run_id}")
+    agent_mod = load_agent_module(args.version)
+
+    try:
+        result = evaluate(
+            function=make_run_support_agent(agent_mod.build_agents),
+            dataset=dataset,
+            evaluators=[response_quality],
+            instrumentors=[
+                lambda: GoogleADKInstrumentor(),
+            ],
+            name=f"customer-support-eval-{args.version}",
+        )
+        run_id = result.run_id
+    except ValidationError:
+        # Experiment runs + uploads fine; a pre-existing HoneyHive SDK bug
+        # crashes only when parsing the final summary response. Scores are
+        # still available in the HoneyHive UI.
+        run_id = None
+
+    print(f"Version:   {args.version}")
+    if run_id:
+        print(f"Run ID:    {run_id}")
+    else:
+        print("Run completed (summary fetch failed due to an SDK bug).")
     print("View results in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -5,6 +5,7 @@ Run:
     uv run python evaluate.py
 """
 
+import re
 import uuid
 
 from dotenv import load_dotenv
@@ -20,11 +21,56 @@ from main import APP_NAME, USER_ID, build_agent_input, build_agents, extract_tex
 load_dotenv()
 
 openai_client = OpenAI()
+SPECIALIST_CATEGORIES = {
+    "billing_agent": "billing",
+    "technical_agent": "technical",
+}
+SCORE_PATTERN = re.compile(r"\b(?:0(?:\.\d+)?|1(?:\.0+)?)\b")
+
+
+def get_query(datapoint: dict) -> str:
+    """Validate and return the customer query from an eval datapoint."""
+    inputs = datapoint.get("inputs")
+    if not isinstance(inputs, dict):
+        raise ValueError("Datapoint must include an 'inputs' dictionary.")
+
+    query = inputs.get("query")
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("Datapoint must include a non-empty 'inputs.query' string.")
+
+    return query.strip()
+
+
+def parse_judge_score(raw_score: str | None) -> float:
+    """Extract a 0.0-1.0 score from an LLM judge response."""
+    if not raw_score:
+        raise ValueError("Judge returned an empty score.")
+
+    match = SCORE_PATTERN.search(raw_score)
+    if match is None:
+        raise ValueError(f"Judge did not return a numeric score: {raw_score!r}")
+
+    score = float(match.group(0))
+    if not 0.0 <= score <= 1.0:
+        raise ValueError(f"Judge score must be between 0.0 and 1.0, got {score}.")
+    return score
+
+
+def detect_specialist(authors: list[str]) -> str:
+    """Infer which specialist handled the request from ADK event authors."""
+    specialists = [author for author in authors if author in SPECIALIST_CATEGORIES]
+    unique_specialists = list(dict.fromkeys(specialists))
+
+    if len(unique_specialists) == 1:
+        return unique_specialists[0]
+    if len(unique_specialists) > 1:
+        return "multiple"
+    return "unknown"
 
 
 async def run_support_agent(datapoint: dict) -> dict:
     """Run the support agent on a single datapoint."""
-    query = datapoint["inputs"]["query"]
+    query = get_query(datapoint)
 
     coordinator = build_agents()
     session_service = InMemorySessionService()
@@ -45,82 +91,67 @@ async def run_support_agent(datapoint: dict) -> dict:
     agent_input = build_agent_input(query, USER_ID)
     msg = Content(role="user", parts=[Part(text=agent_input)])
     response_text = ""
+    event_authors: list[str] = []
     async for event in runner.run_async(
         user_id=USER_ID,
         session_id=session_id,
         new_message=msg,
     ):
+        author = getattr(event, "author", None)
+        if isinstance(author, str):
+            event_authors.append(author)
         if event.is_final_response():
             response_text = extract_text(event.content)
 
-    return {"response": response_text}
+    return {
+        "response": response_text,
+        "handled_by": detect_specialist(event_authors),
+        "event_authors": event_authors,
+    }
 
 
 def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
     """Judge whether the response is accurate, helpful, and appropriately toned."""
-    try:
-        result = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
-            temperature=0,
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "You evaluate customer support responses.\n"
-                        "Score the response from 0.0 to 1.0 based on:\n"
-                        "- whether it answers the question\n"
-                        "- whether it is accurate for the expected category\n"
-                        "- whether the tone is professional and helpful\n\n"
-                        "Reply with only a number between 0.0 and 1.0."
-                    ),
-                },
-                {
-                    "role": "user",
-                    "content": (
-                        f"Customer query: {inputs['query']}\n"
-                        f"Expected category: {ground_truth['category']}\n"
-                        f"Agent response: {outputs.get('response', '')}"
-                    ),
-                },
-            ],
-        )
-        return float(result.choices[0].message.content.strip())
-    except Exception:
-        return 0.0
+    result = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You evaluate customer support responses.\n"
+                    "Score the response from 0.0 to 1.0 based on:\n"
+                    "- whether it answers the question\n"
+                    "- whether it is accurate for the expected category\n"
+                    "- whether the tone is professional and helpful\n\n"
+                    "Reply with only a number between 0.0 and 1.0."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Customer query: {inputs['query']}\n"
+                    f"Expected category: {ground_truth['category']}\n"
+                    f"Agent response: {outputs.get('response', '')}"
+                ),
+            },
+        ],
+    )
+    return parse_judge_score(result.choices[0].message.content)
 
 
 def correct_routing(outputs: dict, inputs: dict, ground_truth: dict) -> float:
-    """Judge whether the query reached the right specialist."""
-    try:
-        result = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
-            temperature=0,
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "You judge specialist routing for a customer support system.\n"
-                        "The available specialists are:\n"
-                        "- billing: charges, balances, invoices, refunds, payments\n"
-                        "- technical: bugs, login problems, exports, APIs, troubleshooting\n\n"
-                        "Based on the query and response, decide whether the response came from "
-                        "the correct specialist for the expected category.\n"
-                        "Reply with only 1.0 for correct routing or 0.0 for incorrect routing."
-                    ),
-                },
-                {
-                    "role": "user",
-                    "content": (
-                        f"Customer query: {inputs['query']}\n"
-                        f"Expected category: {ground_truth['category']}\n"
-                        f"Agent response: {outputs.get('response', '')}"
-                    ),
-                },
-            ],
+    """Check whether ADK delegated the query to the expected specialist."""
+    handled_by = outputs.get("handled_by")
+    if handled_by not in SPECIALIST_CATEGORIES:
+        raise ValueError(
+            "Could not determine a single delegated specialist from ADK events. "
+            f"Observed authors: {outputs.get('event_authors', [])!r}"
         )
-        return float(result.choices[0].message.content.strip())
-    except Exception:
-        return 0.0
+
+    expected_category = ground_truth["category"]
+    observed_category = SPECIALIST_CATEGORIES[handled_by]
+    return 1.0 if observed_category == expected_category else 0.0
 
 
 dataset = [

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -124,4 +124,6 @@ if __name__ == "__main__":
     print(f"Version:   {args.version}")
     if run_id:
         print(f"Run ID:    {run_id}")
+    else:
+        print("Run completed.")
     print("View aggregate scores and traces in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -118,6 +118,9 @@ if __name__ == "__main__":
         )
         run_id = result.run_id
     except ValidationError:
+        # The current pre-release SDK mistypes the run-summary response,
+        # so the final aggregate parse raises after the run has already
+        # uploaded. Remove this once the pinned SDK version is bumped.
         pass
 
     print(f"Version:   {args.version}")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -1,0 +1,176 @@
+"""
+Evaluate the customer support agent using HoneyHive experiments.
+
+Run:
+    uv run python evaluate.py
+"""
+
+import uuid
+
+from dotenv import load_dotenv
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+from openai import OpenAI
+
+from honeyhive import evaluate
+
+from main import APP_NAME, USER_ID, build_agent_input, build_agents, extract_text
+
+load_dotenv()
+
+openai_client = OpenAI()
+
+
+async def run_support_agent(datapoint: dict) -> dict:
+    """Run the support agent on a single datapoint."""
+    query = datapoint["inputs"]["query"]
+
+    coordinator = build_agents()
+    session_service = InMemorySessionService()
+    session_id = f"eval-{uuid.uuid4().hex[:12]}"
+
+    await session_service.create_session(
+        app_name=f"{APP_NAME}-eval",
+        user_id=USER_ID,
+        session_id=session_id,
+    )
+
+    runner = Runner(
+        agent=coordinator,
+        app_name=f"{APP_NAME}-eval",
+        session_service=session_service,
+    )
+
+    agent_input = build_agent_input(query, USER_ID)
+    msg = Content(role="user", parts=[Part(text=agent_input)])
+    response_text = ""
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=session_id,
+        new_message=msg,
+    ):
+        if event.is_final_response():
+            response_text = extract_text(event.content)
+
+    return {"response": response_text}
+
+
+def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
+    """Judge whether the response is accurate, helpful, and appropriately toned."""
+    try:
+        result = openai_client.chat.completions.create(
+            model="gpt-4o-mini",
+            temperature=0,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You evaluate customer support responses.\n"
+                        "Score the response from 0.0 to 1.0 based on:\n"
+                        "- whether it answers the question\n"
+                        "- whether it is accurate for the expected category\n"
+                        "- whether the tone is professional and helpful\n\n"
+                        "Reply with only a number between 0.0 and 1.0."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        f"Customer query: {inputs['query']}\n"
+                        f"Expected category: {ground_truth['category']}\n"
+                        f"Agent response: {outputs.get('response', '')}"
+                    ),
+                },
+            ],
+        )
+        return float(result.choices[0].message.content.strip())
+    except Exception:
+        return 0.0
+
+
+def correct_routing(outputs: dict, inputs: dict, ground_truth: dict) -> float:
+    """Judge whether the query reached the right specialist."""
+    try:
+        result = openai_client.chat.completions.create(
+            model="gpt-4o-mini",
+            temperature=0,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You judge specialist routing for a customer support system.\n"
+                        "The available specialists are:\n"
+                        "- billing: charges, balances, invoices, refunds, payments\n"
+                        "- technical: bugs, login problems, exports, APIs, troubleshooting\n\n"
+                        "Based on the query and response, decide whether the response came from "
+                        "the correct specialist for the expected category.\n"
+                        "Reply with only 1.0 for correct routing or 0.0 for incorrect routing."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        f"Customer query: {inputs['query']}\n"
+                        f"Expected category: {ground_truth['category']}\n"
+                        f"Agent response: {outputs.get('response', '')}"
+                    ),
+                },
+            ],
+        )
+        return float(result.choices[0].message.content.strip())
+    except Exception:
+        return 0.0
+
+
+dataset = [
+    {
+        "inputs": {"query": "I was charged $24.50 but I thought that was refunded?"},
+        "ground_truth": {"category": "billing"},
+    },
+    {
+        "inputs": {"query": "What's my current account balance?"},
+        "ground_truth": {"category": "billing"},
+    },
+    {
+        "inputs": {"query": "Can you show me my recent charges for this month?"},
+        "ground_truth": {"category": "billing"},
+    },
+    {
+        "inputs": {"query": "The export button gives me error 500."},
+        "ground_truth": {"category": "technical"},
+    },
+    {
+        "inputs": {"query": "I can't log in. The password reset email never arrived."},
+        "ground_truth": {"category": "technical"},
+    },
+    {
+        "inputs": {"query": "Our API calls are getting rate limited. How do we increase the limit?"},
+        "ground_truth": {"category": "technical"},
+    },
+    {
+        "inputs": {"query": "I need a refund for the duplicate charge on Feb 5th."},
+        "ground_truth": {"category": "billing"},
+    },
+    {
+        "inputs": {"query": "How do I export data from the dashboard? It keeps failing."},
+        "ground_truth": {"category": "technical"},
+    },
+]
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Customer Support Agent - Evaluation")
+    print("=" * 60)
+
+    result = evaluate(
+        function=run_support_agent,
+        dataset=dataset,
+        evaluators=[response_quality, correct_routing],
+        name="customer-support-eval",
+    )
+
+    print(f"\nExperiment run_id: {result.run_id}")
+    print("View results in HoneyHive: https://app.honeyhive.ai")
+    print("=" * 60)

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -16,7 +16,7 @@ from openai import OpenAI
 
 from honeyhive import evaluate
 
-from main import APP_NAME, USER_ID, build_agent_input, build_agents, extract_text
+from main import APP_NAME, USER_ID, build_agent_input, build_agents
 
 load_dotenv()
 
@@ -100,8 +100,8 @@ async def run_support_agent(datapoint: dict) -> dict:
         author = getattr(event, "author", None)
         if isinstance(author, str):
             event_authors.append(author)
-        if event.is_final_response():
-            response_text = extract_text(event.content)
+        if event.is_final_response() and event.content and event.content.parts:
+            response_text = event.content.parts[0].text or ""
 
     return {
         "response": response_text,

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -124,6 +124,4 @@ if __name__ == "__main__":
     print(f"Version:   {args.version}")
     if run_id:
         print(f"Run ID:    {run_id}")
-    else:
-        print("Run completed.")
     print("View aggregate scores and traces in HoneyHive: https://app.honeyhive.ai")

--- a/google-adk-cookbook/evaluate.py
+++ b/google-adk-cookbook/evaluate.py
@@ -5,7 +5,7 @@ Run:
     uv run python evaluate.py
 """
 
-import re
+import json
 import uuid
 
 from dotenv import load_dotenv
@@ -13,6 +13,8 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import Content, Part
 from openai import OpenAI
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+from openinference.instrumentation.openai import OpenAIInstrumentor
 
 from honeyhive import evaluate
 
@@ -21,44 +23,16 @@ from main import APP_NAME, USER_ID, build_agent_input, build_agents
 load_dotenv()
 
 openai_client = OpenAI()
-SPECIALIST_CATEGORIES = {
-    "billing_agent": "billing",
-    "technical_agent": "technical",
-}
-SCORE_PATTERN = re.compile(r"\b(?:0(?:\.\d+)?|1(?:\.0+)?)\b")
-
-
-def get_query(datapoint: dict) -> str:
-    """Validate and return the customer query from an eval datapoint."""
-    inputs = datapoint.get("inputs")
-    if not isinstance(inputs, dict):
-        raise ValueError("Datapoint must include an 'inputs' dictionary.")
-
-    query = inputs.get("query")
-    if not isinstance(query, str) or not query.strip():
-        raise ValueError("Datapoint must include a non-empty 'inputs.query' string.")
-
-    return query.strip()
-
-
-def parse_judge_score(raw_score: str | None) -> float:
-    """Extract a 0.0-1.0 score from an LLM judge response."""
-    if not raw_score:
-        raise ValueError("Judge returned an empty score.")
-
-    match = SCORE_PATTERN.search(raw_score)
-    if match is None:
-        raise ValueError(f"Judge did not return a numeric score: {raw_score!r}")
-
-    score = float(match.group(0))
-    if not 0.0 <= score <= 1.0:
-        raise ValueError(f"Judge score must be between 0.0 and 1.0, got {score}.")
-    return score
 
 
 def detect_specialist(authors: list[str]) -> str:
     """Infer which specialist handled the request from ADK event authors."""
-    specialists = [author for author in authors if author in SPECIALIST_CATEGORIES]
+    specialists = []
+    for author in authors:
+        if author == "billing_agent":
+            specialists.append("billing")
+        elif author == "technical_agent":
+            specialists.append("technical")
     unique_specialists = list(dict.fromkeys(specialists))
 
     if len(unique_specialists) == 1:
@@ -70,7 +44,7 @@ def detect_specialist(authors: list[str]) -> str:
 
 async def run_support_agent(datapoint: dict) -> dict:
     """Run the support agent on a single datapoint."""
-    query = get_query(datapoint)
+    query = datapoint["inputs"]["query"].strip()
 
     coordinator = build_agents()
     session_service = InMemorySessionService()
@@ -115,6 +89,7 @@ def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
     result = openai_client.chat.completions.create(
         model="gpt-4o-mini",
         temperature=0,
+        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
@@ -124,7 +99,7 @@ def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
                     "- whether it answers the question\n"
                     "- whether it is accurate for the expected category\n"
                     "- whether the tone is professional and helpful\n\n"
-                    "Reply with only a number between 0.0 and 1.0."
+                    'Respond with JSON of the form {"score": <number between 0.0 and 1.0>}.'
                 ),
             },
             {
@@ -137,21 +112,26 @@ def response_quality(outputs: dict, inputs: dict, ground_truth: dict) -> float:
             },
         ],
     )
-    return parse_judge_score(result.choices[0].message.content)
+    raw = result.choices[0].message.content
+    if not raw:
+        raise ValueError("Judge returned an empty response.")
+
+    score = float(json.loads(raw)["score"])
+    if not 0.0 <= score <= 1.0:
+        raise ValueError(f"Judge score must be between 0.0 and 1.0, got {score}.")
+    return score
 
 
 def correct_routing(outputs: dict, inputs: dict, ground_truth: dict) -> float:
     """Check whether ADK delegated the query to the expected specialist."""
     handled_by = outputs.get("handled_by")
-    if handled_by not in SPECIALIST_CATEGORIES:
+    if handled_by not in {"billing", "technical"}:
         raise ValueError(
             "Could not determine a single delegated specialist from ADK events. "
             f"Observed authors: {outputs.get('event_authors', [])!r}"
         )
 
-    expected_category = ground_truth["category"]
-    observed_category = SPECIALIST_CATEGORIES[handled_by]
-    return 1.0 if observed_category == expected_category else 0.0
+    return 1.0 if handled_by == ground_truth["category"] else 0.0
 
 
 dataset = [
@@ -199,6 +179,10 @@ if __name__ == "__main__":
         function=run_support_agent,
         dataset=dataset,
         evaluators=[response_quality, correct_routing],
+        instrumentors=[
+            lambda: GoogleADKInstrumentor(),
+            lambda: OpenAIInstrumentor(),
+        ],
         name="customer-support-eval",
     )
 

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -14,6 +14,7 @@ import os
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import Content, Part
@@ -23,7 +24,7 @@ from honeyhive import HoneyHiveTracer, trace
 
 load_dotenv()
 
-MODEL = "gemini-flash-latest"
+MODEL = LiteLlm(model="openai/gpt-4o-mini")
 APP_NAME = "customer-support-cookbook"
 USER_ID = "customer_42"
 CUSTOMER_DB = {
@@ -144,14 +145,6 @@ def build_agents() -> LlmAgent:
     )
 
 
-def extract_text(content: Content | None) -> str:
-    """Return only text parts from an ADK content payload."""
-    if not content or not getattr(content, "parts", None):
-        return ""
-    text_parts = [part.text for part in content.parts if getattr(part, "text", None)]
-    return "\n".join(text_parts).strip()
-
-
 # HoneyHive custom spans are useful for your own app-layer work outside ADK,
 # like loading customer records before handing a request to the agent.
 @trace()
@@ -197,8 +190,8 @@ async def handle_customer_query(runner: Runner, session_id: str, query: str) -> 
         session_id=session_id,
         new_message=msg,
     ):
-        if event.is_final_response():
-            response_text = extract_text(event.content)
+        if event.is_final_response() and event.content and event.content.parts:
+            response_text = event.content.parts[0].text or ""
     return response_text
 
 
@@ -265,9 +258,7 @@ async def main() -> None:
         print("Check HoneyHive dashboard for traces.")
         print("=" * 60)
     finally:
-        flush = getattr(tracer, "force_flush", None) or getattr(tracer, "flush", None)
-        if callable(flush):
-            flush()
+        tracer.flush()
         instrumentor.uninstrument()
 
 

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -23,7 +23,7 @@ from honeyhive import HoneyHiveTracer, trace
 
 load_dotenv()
 
-MODEL = "gemini-2.5-flash"
+MODEL = "gemini-flash-latest"
 APP_NAME = "customer-support-cookbook"
 USER_ID = "customer_42"
 CUSTOMER_DB = {

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -24,78 +24,33 @@ from honeyhive import HoneyHiveTracer, trace
 
 load_dotenv()
 
-MODEL = LiteLlm(model="openai/gpt-4o-mini")
+MODEL = LiteLlm(model="openai/gpt-5.4-mini")
 APP_NAME = "customer-support-cookbook"
 USER_ID = "customer_42"
 CUSTOMER_DB = {
-    USER_ID: {
-        "billing_customer_id": "CUST-2048",
-        "plan": "enterprise",
-        "support_tier": "priority",
-        "account_status": "active",
-        "region": "us-east-1",
-    }
+    USER_ID: {"plan": "enterprise", "billing_customer_id": "CUST-2048"},
 }
 
 
 def lookup_billing(customer_id: str, query_type: str) -> dict:
     """Look up billing information for a customer."""
-    records = {
-        "balance": {
-            "customer_id": customer_id,
-            "current_balance": "$1,247.50",
-            "due_date": "2026-03-01",
-            "status": "current",
-        },
-        "charges": {
-            "customer_id": customer_id,
-            "recent_charges": [
-                {"date": "2026-02-01", "amount": "$99.00", "description": "Monthly subscription"},
-                {"date": "2026-02-05", "amount": "$24.50", "description": "API overage"},
-            ],
-        },
-        "refund_status": {
-            "customer_id": customer_id,
-            "refund_id": "REF-2026-0142",
-            "amount": "$24.50",
-            "status": "processing",
-            "estimated_completion": "2026-02-20",
-        },
-    }
-    return records.get(query_type, {"error": f"Unknown query type: {query_type}"})
+    if query_type == "balance":
+        return {"customer_id": customer_id, "balance": "$1,247.50", "due": "2026-03-01"}
+    if query_type == "refund_status":
+        return {"customer_id": customer_id, "refund_id": "REF-2026-0142", "amount": "$24.50", "status": "processing"}
+    return {"error": f"Unknown query type: {query_type}"}
 
 
 def search_knowledge_base(issue: str) -> dict:
     """Search the technical knowledge base for solutions to product issues."""
-    solutions = {
-        "export": {
-            "title": "Export Feature - Error 500",
-            "solution": "Clear browser cache and retry. If the issue persists, check that "
-            "your dataset is under 10,000 rows (the export limit for free plans).",
-            "article_id": "KB-1042",
-        },
-        "api": {
-            "title": "API Rate Limiting",
-            "solution": "The default rate limit is 100 requests/minute. Enterprise plans "
-            "support up to 1,000 requests/minute. Add exponential backoff to your client.",
-            "article_id": "KB-0891",
-        },
-        "login": {
-            "title": "Login / Authentication Issues",
-            "solution": "Try resetting your password at /reset-password. If using SSO, "
-            "confirm your identity provider is configured correctly in Settings > SSO.",
-            "article_id": "KB-0567",
-        },
-    }
-    issue_lower = issue.lower()
-    for keyword, article in solutions.items():
-        if keyword in issue_lower:
-            return article
-    return {
-        "title": "General Troubleshooting",
-        "solution": "Please provide more details about your issue so we can help.",
-        "article_id": "KB-0001",
-    }
+    issue = issue.lower()
+    if "export" in issue:
+        return {"article_id": "KB-1042", "solution": "Clear browser cache and retry. Free-plan exports are capped at 10k rows."}
+    if "api" in issue:
+        return {"article_id": "KB-0891", "solution": "Default rate limit is 100 req/min. Enterprise gets 1000 req/min."}
+    if "login" in issue:
+        return {"article_id": "KB-0567", "solution": "Reset at /reset-password. For SSO, check Settings > SSO."}
+    return {"article_id": "KB-0001", "solution": "Please provide more details."}
 
 
 def build_agents() -> LlmAgent:
@@ -103,161 +58,111 @@ def build_agents() -> LlmAgent:
     billing_agent = LlmAgent(
         name="billing_agent",
         model=MODEL,
-        description=(
-            "Handles billing inquiries including balances, recent charges, "
-            "refund status, invoices, and payment questions."
-        ),
+        description="Handles billing: balances, charges, refund status, invoices.",
         instruction=(
-            "You are a billing support specialist.\n"
-            "Use the lookup_billing tool for account balances, charges, or refunds.\n"
-            "Summarize the result clearly with amounts, dates, and the next step.\n"
-            "If the customer has not provided a customer ID, ask for it."
+            "You are a billing support specialist. "
+            "Use lookup_billing for balances, charges, or refunds. "
+            "Summarize the result with amounts, dates, and the next step."
         ),
         tools=[lookup_billing],
     )
-
     technical_agent = LlmAgent(
         name="technical_agent",
         model=MODEL,
-        description=(
-            "Handles product bugs, feature questions, API issues, and general troubleshooting."
-        ),
+        description="Handles product bugs, API questions, and general troubleshooting.",
         instruction=(
-            "You are a technical support specialist.\n"
-            "Use the search_knowledge_base tool for bugs, errors, export issues, login problems, "
-            "and API questions.\n"
-            "Respond with concrete troubleshooting steps and note when an issue may need escalation."
+            "You are a technical support specialist. "
+            "Use search_knowledge_base for bugs, exports, login, and API questions. "
+            "Respond with concrete troubleshooting steps."
         ),
         tools=[search_knowledge_base],
     )
-
     return LlmAgent(
         name="customer_support",
         model=MODEL,
         description="Routes customer support requests to the right specialist.",
         instruction=(
-            "You are the front-line customer support coordinator.\n"
-            "Delegate billing issues to billing_agent.\n"
-            "Delegate product bugs, login issues, exports, and API questions to technical_agent.\n"
-            "Do not answer specialist questions yourself. Always delegate first and then return a concise final response."
+            "You are the front-line customer support coordinator. "
+            "Delegate billing issues to billing_agent; product, login, export, and API issues to technical_agent. "
+            "Do not answer specialist questions yourself — always delegate first, then return a concise final response."
         ),
         sub_agents=[billing_agent, technical_agent],
     )
 
 
-# HoneyHive custom spans are useful for your own app-layer work outside ADK,
-# like loading customer records before handing a request to the agent.
+# @trace() captures this app-layer function as a custom HoneyHive span,
+# so it shows up alongside the auto-instrumented ADK spans.
 @trace()
 def load_customer_context(customer_id: str) -> dict:
     """Load customer context from the application data store."""
-    return CUSTOMER_DB.get(
-        customer_id,
-        {
-            "billing_customer_id": customer_id,
-            "plan": "unknown",
-            "support_tier": "standard",
-            "account_status": "unknown",
-            "region": "unknown",
-        },
-    )
+    return CUSTOMER_DB.get(customer_id, {"plan": "unknown", "billing_customer_id": customer_id})
 
 
 def build_agent_input(query: str, customer_id: str) -> str:
-    """Combine the raw query with customer context before sending it to ADK."""
-    customer_context = load_customer_context(customer_id)
+    """Prepend customer context to the raw query before sending it to ADK."""
+    ctx = load_customer_context(customer_id)
     return (
-        "Authenticated customer context:\n"
-        f"- internal_user_id: {customer_id}\n"
-        f"- billing_customer_id: {customer_context['billing_customer_id']}\n"
-        f"- plan: {customer_context['plan']}\n"
-        f"- support_tier: {customer_context['support_tier']}\n"
-        f"- account_status: {customer_context['account_status']}\n"
-        f"- region: {customer_context['region']}\n\n"
-        "Use this context when it helps answer the request. "
-        "Do not repeat internal metadata unless it is relevant.\n\n"
+        f"Customer context: user_id={customer_id}, plan={ctx['plan']}, "
+        f"billing_customer_id={ctx['billing_customer_id']}\n\n"
         f"Customer request: {query.strip()}"
     )
 
 
-async def handle_customer_query(runner: Runner, session_id: str, query: str) -> str:
-    """Send a query to the support agent and return the final response text."""
-    agent_input = build_agent_input(query, USER_ID)
-    msg = Content(role="user", parts=[Part(text=agent_input)])
+async def handle_customer_query(
+    runner: Runner, session_id: str, query: str
+) -> tuple[str, list[str]]:
+    """Send a query to the support agent.
+
+    Returns the final response text and the list of ADK event authors
+    (used by `evaluate.py` to verify which specialist handled the query).
+    """
+    msg = Content(role="user", parts=[Part(text=build_agent_input(query, USER_ID))])
 
     response_text = ""
+    event_authors: list[str] = []
     async for event in runner.run_async(
-        user_id=USER_ID,
-        session_id=session_id,
-        new_message=msg,
+        user_id=USER_ID, session_id=session_id, new_message=msg
     ):
+        author = getattr(event, "author", None)
+        if isinstance(author, str):
+            event_authors.append(author)
         if event.is_final_response() and event.content and event.content.parts:
             response_text = event.content.parts[0].text or ""
-    return response_text
+    return response_text, event_authors
 
 
 async def main() -> None:
     """Run the tracing demo."""
+    # --- HoneyHive setup (3 lines) ---
     tracer = HoneyHiveTracer.init(
         api_key=os.getenv("HH_API_KEY"),
         project=os.getenv("HH_PROJECT"),
         session_name="customer-support",
         source="cookbook",
     )
-    instrumentor = GoogleADKInstrumentor()
-    instrumentor.instrument(tracer_provider=tracer.provider)
-    session_service = InMemorySessionService()
+    GoogleADKInstrumentor().instrument(tracer_provider=tracer.provider)
+    tracer.enrich_session(
+        user_properties={"user_id": USER_ID, "plan": "enterprise"},
+        metadata={"environment": os.getenv("HH_ENV", "local"), "app_version": "2.1.0"},
+    )
 
+    # --- ADK app (unchanged by HoneyHive) ---
     try:
-        tracer.enrich_session(
-            user_properties={
-                "user_id": USER_ID,
-                "plan": "enterprise",
-            },
-            metadata={
-                "environment": os.getenv("HH_ENV", "local"),
-                "app_version": "2.1.0",
-            },
-        )
-
-        coordinator = build_agents()
+        session_service = InMemorySessionService()
         runner = Runner(
-            agent=coordinator,
-            app_name=APP_NAME,
-            session_service=session_service,
+            agent=build_agents(), app_name=APP_NAME, session_service=session_service
         )
-        queries = [
-            "I was charged $24.50 last week but I thought that was supposed to be refunded?",
-            "The export button gives me an error 500 when I try to download my data.",
-            "What's my current account balance?",
-        ]
-
-        print("=" * 60)
-        print("Customer Support Agent (Google ADK + HoneyHive)")
-        print("=" * 60)
-
-        # Reuse one ADK session for the whole HoneyHive session, so the
-        # conversation history is continuous and matches the trace.
-        session_id = tracer.session_id
         await session_service.create_session(
-            app_name=APP_NAME,
-            user_id=USER_ID,
-            session_id=session_id,
+            app_name=APP_NAME, user_id=USER_ID, session_id=tracer.session_id
         )
 
-        for query in queries:
-            print(f"\nCustomer: {query}")
-            response = await handle_customer_query(runner, session_id, query)
-            preview = response[:200]
-            suffix = "..." if len(response) > 200 else ""
-            print(f"Agent:    {preview}{suffix}")
-
-        print("\n" + "=" * 60)
+        query = "I was charged $24.50 last week but I thought that was supposed to be refunded?"
+        print(f"Customer: {query}")
+        response, _ = await handle_customer_query(runner, tracer.session_id, query)
+        print(f"Agent:    {response}")
         print(f"Session ID: {tracer.session_id}")
-        print("Check HoneyHive dashboard for traces.")
-        print("=" * 60)
     finally:
         tracer.flush()
-        instrumentor.uninstrument()
 
 
 if __name__ == "__main__":

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -204,11 +204,7 @@ async def main() -> None:
         source="cookbook",
     )
     instrumentor = GoogleADKInstrumentor()
-    tracer_provider = getattr(tracer, "provider", None)
-    if tracer_provider is not None:
-        instrumentor.instrument(tracer_provider=tracer_provider)
-    else:
-        instrumentor.instrument()
+    instrumentor.instrument(tracer_provider=tracer.provider)
     session_service = InMemorySessionService()
 
     try:
@@ -239,14 +235,16 @@ async def main() -> None:
         print("Customer Support Agent (Google ADK + HoneyHive)")
         print("=" * 60)
 
-        for i, query in enumerate(queries):
-            session_id = f"{tracer.session_id}-{i}"
-            await session_service.create_session(
-                app_name=APP_NAME,
-                user_id=USER_ID,
-                session_id=session_id,
-            )
+        # Reuse one ADK session for the whole HoneyHive session, so the
+        # conversation history is continuous and matches the trace.
+        session_id = tracer.session_id
+        await session_service.create_session(
+            app_name=APP_NAME,
+            user_id=USER_ID,
+            session_id=session_id,
+        )
 
+        for query in queries:
             print(f"\nCustomer: {query}")
             response = await handle_customer_query(runner, session_id, query)
             preview = response[:200]

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -1,0 +1,275 @@
+"""
+Multi-agent customer support app with HoneyHive observability.
+
+A coordinator agent routes customer queries to specialist sub-agents:
+  - billing_agent: handles charges, refunds, invoices
+  - technical_agent: handles product issues, troubleshooting
+
+Run:
+    uv run python main.py
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+from honeyhive import HoneyHiveTracer, trace
+
+load_dotenv()
+
+MODEL = "gemini-2.5-flash"
+APP_NAME = "customer-support-cookbook"
+USER_ID = "customer_42"
+CUSTOMER_DB = {
+    USER_ID: {
+        "billing_customer_id": "CUST-2048",
+        "plan": "enterprise",
+        "support_tier": "priority",
+        "account_status": "active",
+        "region": "us-east-1",
+    }
+}
+
+
+def lookup_billing(customer_id: str, query_type: str) -> dict:
+    """Look up billing information for a customer."""
+    records = {
+        "balance": {
+            "customer_id": customer_id,
+            "current_balance": "$1,247.50",
+            "due_date": "2026-03-01",
+            "status": "current",
+        },
+        "charges": {
+            "customer_id": customer_id,
+            "recent_charges": [
+                {"date": "2026-02-01", "amount": "$99.00", "description": "Monthly subscription"},
+                {"date": "2026-02-05", "amount": "$24.50", "description": "API overage"},
+            ],
+        },
+        "refund_status": {
+            "customer_id": customer_id,
+            "refund_id": "REF-2026-0142",
+            "amount": "$24.50",
+            "status": "processing",
+            "estimated_completion": "2026-02-20",
+        },
+    }
+    return records.get(query_type, {"error": f"Unknown query type: {query_type}"})
+
+
+def search_knowledge_base(issue: str) -> dict:
+    """Search the technical knowledge base for solutions to product issues."""
+    solutions = {
+        "export": {
+            "title": "Export Feature - Error 500",
+            "solution": "Clear browser cache and retry. If the issue persists, check that "
+            "your dataset is under 10,000 rows (the export limit for free plans).",
+            "article_id": "KB-1042",
+        },
+        "api": {
+            "title": "API Rate Limiting",
+            "solution": "The default rate limit is 100 requests/minute. Enterprise plans "
+            "support up to 1,000 requests/minute. Add exponential backoff to your client.",
+            "article_id": "KB-0891",
+        },
+        "login": {
+            "title": "Login / Authentication Issues",
+            "solution": "Try resetting your password at /reset-password. If using SSO, "
+            "confirm your identity provider is configured correctly in Settings > SSO.",
+            "article_id": "KB-0567",
+        },
+    }
+    issue_lower = issue.lower()
+    for keyword, article in solutions.items():
+        if keyword in issue_lower:
+            return article
+    return {
+        "title": "General Troubleshooting",
+        "solution": "Please provide more details about your issue so we can help.",
+        "article_id": "KB-0001",
+    }
+
+
+def build_agents() -> LlmAgent:
+    """Build the multi-agent customer support system."""
+    billing_agent = LlmAgent(
+        name="billing_agent",
+        model=MODEL,
+        description=(
+            "Handles billing inquiries including balances, recent charges, "
+            "refund status, invoices, and payment questions."
+        ),
+        instruction=(
+            "You are a billing support specialist.\n"
+            "Use the lookup_billing tool for account balances, charges, or refunds.\n"
+            "Summarize the result clearly with amounts, dates, and the next step.\n"
+            "If the customer has not provided a customer ID, ask for it."
+        ),
+        tools=[lookup_billing],
+    )
+
+    technical_agent = LlmAgent(
+        name="technical_agent",
+        model=MODEL,
+        description=(
+            "Handles product bugs, feature questions, API issues, and general troubleshooting."
+        ),
+        instruction=(
+            "You are a technical support specialist.\n"
+            "Use the search_knowledge_base tool for bugs, errors, export issues, login problems, "
+            "and API questions.\n"
+            "Respond with concrete troubleshooting steps and note when an issue may need escalation."
+        ),
+        tools=[search_knowledge_base],
+    )
+
+    return LlmAgent(
+        name="customer_support",
+        model=MODEL,
+        description="Routes customer support requests to the right specialist.",
+        instruction=(
+            "You are the front-line customer support coordinator.\n"
+            "Delegate billing issues to billing_agent.\n"
+            "Delegate product bugs, login issues, exports, and API questions to technical_agent.\n"
+            "Do not answer specialist questions yourself. Always delegate first and then return a concise final response."
+        ),
+        sub_agents=[billing_agent, technical_agent],
+    )
+
+
+def extract_text(content: Content | None) -> str:
+    """Return only text parts from an ADK content payload."""
+    if not content or not getattr(content, "parts", None):
+        return ""
+    text_parts = [part.text for part in content.parts if getattr(part, "text", None)]
+    return "\n".join(text_parts).strip()
+
+
+# HoneyHive custom spans are useful for your own app-layer work outside ADK,
+# like loading customer records before handing a request to the agent.
+@trace()
+def load_customer_context(customer_id: str) -> dict:
+    """Load customer context from the application data store."""
+    return CUSTOMER_DB.get(
+        customer_id,
+        {
+            "billing_customer_id": customer_id,
+            "plan": "unknown",
+            "support_tier": "standard",
+            "account_status": "unknown",
+            "region": "unknown",
+        },
+    )
+
+
+def build_agent_input(query: str, customer_id: str) -> str:
+    """Combine the raw query with customer context before sending it to ADK."""
+    customer_context = load_customer_context(customer_id)
+    return (
+        "Authenticated customer context:\n"
+        f"- internal_user_id: {customer_id}\n"
+        f"- billing_customer_id: {customer_context['billing_customer_id']}\n"
+        f"- plan: {customer_context['plan']}\n"
+        f"- support_tier: {customer_context['support_tier']}\n"
+        f"- account_status: {customer_context['account_status']}\n"
+        f"- region: {customer_context['region']}\n\n"
+        "Use this context when it helps answer the request. "
+        "Do not repeat internal metadata unless it is relevant.\n\n"
+        f"Customer request: {query.strip()}"
+    )
+
+
+async def handle_customer_query(runner: Runner, session_id: str, query: str) -> str:
+    """Send a query to the support agent and return the final response text."""
+    agent_input = build_agent_input(query, USER_ID)
+    msg = Content(role="user", parts=[Part(text=agent_input)])
+
+    response_text = ""
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=session_id,
+        new_message=msg,
+    ):
+        if event.is_final_response():
+            response_text = extract_text(event.content)
+    return response_text
+
+
+async def main() -> None:
+    """Run the tracing demo."""
+    tracer = HoneyHiveTracer.init(
+        api_key=os.getenv("HH_API_KEY"),
+        project=os.getenv("HH_PROJECT"),
+        session_name="customer-support",
+        source="cookbook",
+    )
+    instrumentor = GoogleADKInstrumentor()
+    tracer_provider = getattr(tracer, "provider", None)
+    if tracer_provider is not None:
+        instrumentor.instrument(tracer_provider=tracer_provider)
+    else:
+        instrumentor.instrument()
+    session_service = InMemorySessionService()
+
+    try:
+        tracer.enrich_session(
+            user_properties={
+                "user_id": USER_ID,
+                "plan": "enterprise",
+            },
+            metadata={
+                "environment": os.getenv("HH_ENV", "local"),
+                "app_version": "2.1.0",
+            },
+        )
+
+        coordinator = build_agents()
+        runner = Runner(
+            agent=coordinator,
+            app_name=APP_NAME,
+            session_service=session_service,
+        )
+        queries = [
+            "I was charged $24.50 last week but I thought that was supposed to be refunded?",
+            "The export button gives me an error 500 when I try to download my data.",
+            "What's my current account balance?",
+        ]
+
+        print("=" * 60)
+        print("Customer Support Agent (Google ADK + HoneyHive)")
+        print("=" * 60)
+
+        for i, query in enumerate(queries):
+            session_id = f"{tracer.session_id}-{i}"
+            await session_service.create_session(
+                app_name=APP_NAME,
+                user_id=USER_ID,
+                session_id=session_id,
+            )
+
+            print(f"\nCustomer: {query}")
+            response = await handle_customer_query(runner, session_id, query)
+            preview = response[:200]
+            suffix = "..." if len(response) > 200 else ""
+            print(f"Agent:    {preview}{suffix}")
+
+        print("\n" + "=" * 60)
+        print(f"Session ID: {tracer.session_id}")
+        print("Check HoneyHive dashboard for traces.")
+        print("=" * 60)
+    finally:
+        flush = getattr(tracer, "force_flush", None) or getattr(tracer, "flush", None)
+        if callable(flush):
+            flush()
+        instrumentor.uninstrument()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/google-adk-cookbook/main.py
+++ b/google-adk-cookbook/main.py
@@ -1,20 +1,21 @@
 """
-Multi-agent customer support app with HoneyHive observability.
+Multi-agent customer support demo with HoneyHive observability.
 
-A coordinator agent routes customer queries to specialist sub-agents:
-  - billing_agent: handles charges, refunds, invoices
-  - technical_agent: handles product issues, troubleshooting
+Picks either the initial (v1) or improved (v2) agent via --version.
 
 Run:
-    uv run python main.py
+    uv run python main.py --version v1
+    uv run python main.py --version v2
 """
 
+import argparse
 import asyncio
+import importlib
 import os
 
 from dotenv import load_dotenv
-from google.adk.agents import LlmAgent
-from google.adk.models.lite_llm import LiteLlm
+from google.adk.agents.invocation_context import LlmCallsLimitExceededError
+from google.adk.agents.run_config import RunConfig
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import Content, Part
@@ -22,72 +23,22 @@ from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 from honeyhive import HoneyHiveTracer, trace
 
-load_dotenv()
+load_dotenv(override=True)
 
-MODEL = LiteLlm(model="openai/gpt-5.4-mini")
 APP_NAME = "customer-support-cookbook"
 USER_ID = "customer_42"
 CUSTOMER_DB = {
     USER_ID: {"plan": "enterprise", "billing_customer_id": "CUST-2048"},
 }
+# Cap LLM calls per query so a confused agent fails fast instead of looping.
+RUN_CONFIG = RunConfig(max_llm_calls=15)
 
 
-def lookup_billing(customer_id: str, query_type: str) -> dict:
-    """Look up billing information for a customer."""
-    if query_type == "balance":
-        return {"customer_id": customer_id, "balance": "$1,247.50", "due": "2026-03-01"}
-    if query_type == "refund_status":
-        return {"customer_id": customer_id, "refund_id": "REF-2026-0142", "amount": "$24.50", "status": "processing"}
-    return {"error": f"Unknown query type: {query_type}"}
-
-
-def search_knowledge_base(issue: str) -> dict:
-    """Search the technical knowledge base for solutions to product issues."""
-    issue = issue.lower()
-    if "export" in issue:
-        return {"article_id": "KB-1042", "solution": "Clear browser cache and retry. Free-plan exports are capped at 10k rows."}
-    if "api" in issue:
-        return {"article_id": "KB-0891", "solution": "Default rate limit is 100 req/min. Enterprise gets 1000 req/min."}
-    if "login" in issue:
-        return {"article_id": "KB-0567", "solution": "Reset at /reset-password. For SSO, check Settings > SSO."}
-    return {"article_id": "KB-0001", "solution": "Please provide more details."}
-
-
-def build_agents() -> LlmAgent:
-    """Build the multi-agent customer support system."""
-    billing_agent = LlmAgent(
-        name="billing_agent",
-        model=MODEL,
-        description="Handles billing: balances, charges, refund status, invoices.",
-        instruction=(
-            "You are a billing support specialist. "
-            "Use lookup_billing for balances, charges, or refunds. "
-            "Summarize the result with amounts, dates, and the next step."
-        ),
-        tools=[lookup_billing],
-    )
-    technical_agent = LlmAgent(
-        name="technical_agent",
-        model=MODEL,
-        description="Handles product bugs, API questions, and general troubleshooting.",
-        instruction=(
-            "You are a technical support specialist. "
-            "Use search_knowledge_base for bugs, exports, login, and API questions. "
-            "Respond with concrete troubleshooting steps."
-        ),
-        tools=[search_knowledge_base],
-    )
-    return LlmAgent(
-        name="customer_support",
-        model=MODEL,
-        description="Routes customer support requests to the right specialist.",
-        instruction=(
-            "You are the front-line customer support coordinator. "
-            "Delegate billing issues to billing_agent; product, login, export, and API issues to technical_agent. "
-            "Do not answer specialist questions yourself — always delegate first, then return a concise final response."
-        ),
-        sub_agents=[billing_agent, technical_agent],
-    )
+def load_agent_module(version: str):
+    """Import the agent module for the requested version ("v1" or "v2")."""
+    if version not in {"v1", "v2"}:
+        raise ValueError(f"Unknown version {version!r}. Expected 'v1' or 'v2'.")
+    return importlib.import_module(f"agent_{version}")
 
 
 # @trace() captures this app-layer function as a custom HoneyHive span,
@@ -110,55 +61,56 @@ def build_agent_input(query: str, customer_id: str) -> str:
 
 async def handle_customer_query(
     runner: Runner, session_id: str, query: str
-) -> tuple[str, list[str]]:
-    """Send a query to the support agent.
-
-    Returns the final response text and the list of ADK event authors
-    (used by `evaluate.py` to verify which specialist handled the query).
-    """
+) -> str:
+    """Send a query to the support agent and return the final response text."""
     msg = Content(role="user", parts=[Part(text=build_agent_input(query, USER_ID))])
 
     response_text = ""
-    event_authors: list[str] = []
-    async for event in runner.run_async(
-        user_id=USER_ID, session_id=session_id, new_message=msg
-    ):
-        author = getattr(event, "author", None)
-        if isinstance(author, str):
-            event_authors.append(author)
-        if event.is_final_response() and event.content and event.content.parts:
-            response_text = event.content.parts[0].text or ""
-    return response_text, event_authors
+    try:
+        async for event in runner.run_async(
+            user_id=USER_ID,
+            session_id=session_id,
+            new_message=msg,
+            run_config=RUN_CONFIG,
+        ):
+            if event.is_final_response() and event.content and event.content.parts:
+                response_text = event.content.parts[0].text or ""
+    except LlmCallsLimitExceededError:
+        response_text = "[agent gave up: exceeded max LLM calls without producing a final response]"
+    return response_text
 
 
-async def main() -> None:
-    """Run the tracing demo."""
-    # --- HoneyHive setup (3 lines) ---
+async def main(version: str) -> None:
+    """Run the tracing demo against the selected agent version."""
+    agent_mod = load_agent_module(version)
+
     tracer = HoneyHiveTracer.init(
         api_key=os.getenv("HH_API_KEY"),
         project=os.getenv("HH_PROJECT"),
-        session_name="customer-support",
+        session_name=f"customer-support-{version}",
         source="cookbook",
     )
     GoogleADKInstrumentor().instrument(tracer_provider=tracer.provider)
     tracer.enrich_session(
         user_properties={"user_id": USER_ID, "plan": "enterprise"},
-        metadata={"environment": os.getenv("HH_ENV", "local"), "app_version": "2.1.0"},
+        metadata={"environment": os.getenv("HH_ENV", "local"), "agent_version": version},
     )
 
-    # --- ADK app (unchanged by HoneyHive) ---
     try:
         session_service = InMemorySessionService()
         runner = Runner(
-            agent=build_agents(), app_name=APP_NAME, session_service=session_service
+            agent=agent_mod.build_agents(),
+            app_name=APP_NAME,
+            session_service=session_service,
         )
         await session_service.create_session(
             app_name=APP_NAME, user_id=USER_ID, session_id=tracer.session_id
         )
 
         query = "I was charged $24.50 last week but I thought that was supposed to be refunded?"
+        print(f"Version:  {version}")
         print(f"Customer: {query}")
-        response, _ = await handle_customer_query(runner, tracer.session_id, query)
+        response = await handle_customer_query(runner, tracer.session_id, query)
         print(f"Agent:    {response}")
         print(f"Session ID: {tracer.session_id}")
     finally:
@@ -166,4 +118,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", choices=["v1", "v2"], default="v2")
+    args = parser.parse_args()
+    asyncio.run(main(args.version))

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,0 +1,5 @@
+honeyhive>=1.0.0rc0
+google-adk>=1.0.0
+openinference-instrumentation-google-adk
+python-dotenv
+openai

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,6 +1,7 @@
-honeyhive>=1.0.0rc0,<1.0.0
+honeyhive>=1.0.0rc0
 google-adk>=1.0.0
 litellm
 openinference-instrumentation-google-adk
+openinference-instrumentation-openai
 python-dotenv
 openai

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,4 +1,4 @@
-honeyhive>=1.0.0rc0
+honeyhive>=1.0.0rc21
 google-adk>=1.0.0
 google-genai
 openinference-instrumentation-google-adk

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,4 +1,4 @@
-honeyhive>=1.0.0rc0
+honeyhive>=1.0.0rc0,<1.0.0
 google-adk>=1.0.0
 openinference-instrumentation-google-adk
 python-dotenv

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,7 +1,5 @@
 honeyhive>=1.0.0rc0
 google-adk>=1.0.0
-litellm
+google-genai
 openinference-instrumentation-google-adk
-openinference-instrumentation-openai
 python-dotenv
-openai

--- a/google-adk-cookbook/requirements.txt
+++ b/google-adk-cookbook/requirements.txt
@@ -1,5 +1,6 @@
 honeyhive>=1.0.0rc0,<1.0.0
 google-adk>=1.0.0
+litellm
 openinference-instrumentation-google-adk
 python-dotenv
 openai


### PR DESCRIPTION
## Summary

Adds a Google ADK multi-agent cookbook with end-to-end HoneyHive tracing and evaluation. The cookbook ships as a before/after pair so users can see a quality regression surface in a HoneyHive experiment.

- Multi-agent customer support bot built with Google ADK (`customer_support` coordinator delegating to `billing_agent` and `technical_agent`)
- Two agent versions side by side:
  - `agent_v1.py` — vague tool docstrings and minimal instructions, produces weak responses
  - `agent_v2.py` — detailed tool docstrings and explicit delegation rules, produces concrete responses
- `main.py` and `evaluate.py` accept `--version v1|v2` so the same runner drives both
- Uses Gemini directly via `google-genai` (dropped LiteLLM/OpenAI)
- HoneyHive coverage: `HoneyHiveTracer.init()`, `GoogleADKInstrumentor`, `@trace()` custom span on `load_customer_context`, session enrichment, and `evaluate()` with an LLM-as-judge scorer
- `response_quality` evaluator uses a strict 0 / 0.5 / 1 rubric for unhelpful / partial / fully helpful
- `RunConfig(max_llm_calls=15)` caps agent iterations so a confused v1 run fails fast with a clear `[agent gave up: ...]` message instead of looping

## What reviewers will see in HoneyHive

Running `evaluate.py --version v1` then `evaluate.py --version v2` produces two experiments (`customer-support-eval-v1` vs `customer-support-eval-v2`). The v1 run shows `response_quality` clustered at 0–0.5; v2 clusters at 1.0. Traces include coordinator routing, sub-agent delegation, tool calls, and the custom customer-context span.

## Test plan

- [x] `uv venv && uv pip install -r requirements.txt` resolves on the HoneyHive beta SDK line
- [x] `uv run python main.py --version v1` — agent asks for transaction ID (degraded, expected)
- [x] `uv run python main.py --version v2` — agent returns refund ID and status (correct)
- [x] `uv run python evaluate.py --version v1` completes (~55s), run visible in HoneyHive
- [x] `uv run python evaluate.py --version v2` completes (~27s), run visible in HoneyHive
- [x] Both eval runs capture ADK agent, model, and tool spans per datapoint

## Benign log noise

- OpenInference instrumentor emits `Attempting to (un)instrument while already (un)instrumented` warnings during eval because HoneyHive's per-datapoint tracer factory touches a global singleton. Harmless.
- `google-genai` logs `non-text parts in the response: ['function_call']` whenever ADK emits a `transfer_to_agent` tool call with trailing text. Harmless.