### PR TITLE
HHAI-4967: Strands Lambda handler with HoneyHive tracing

### DIFF
--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -1,30 +1,61 @@
-"""Strands agent on Lambda, traced via HoneyHive.
+"""Strands agent on AWS Lambda, traced end-to-end with HoneyHive.
 
-Three patterns matter here; a reader poking at this later should know why:
+This file is a hands-on workshop example: parts of it are intentionally left as
+``# TODO`` markers so a presenter can fill them in live with GitHub Copilot. The
+surrounding context (imports, types, existing tools, comments) is the prompt
+that primes Copilot to suggest the right next line.
 
-1. HoneyHive tracer + Strands agent are built at module import time so the cost
-   amortizes across Lambda container reuse. A warm invocation skips this entirely.
-2. `MODEL_ARN` is fed straight to `BedrockModel(model_id=...)`. Bedrock's
-   `converse()` accepts foundation-model IDs, regular inference-profile ARNs,
-   and application-inference-profile ARNs interchangeably, so one code path
-   handles all three shapes.
-3. Per-invocation state must be reset — two things bleed across container reuse
-   if you're not careful:
-   (a) session id: use `tracer.with_session()` (OTEL baggage, ContextVar-based,
-       auto-cleanup on scope exit), NOT `session_start()` which stores on the
-       tracer singleton. This is the rc10 fix from customer-nationwide
-       2025-10-28.
-   (b) agent conversation history: the Strands `Agent` accumulates user and
-       assistant turns in `self.messages`. Since `_agent` is the same singleton
-       across warm invocations, invocation N would otherwise see the full
-       history from invocations 1..N-1 — a privacy leak and an ever-growing
-       token bill. Clear `_agent.messages` at the start of each invocation.
+Shape of an invocation::
+
+    Lambda invoke
+        -> HoneyHive session (via tracer.with_session)
+            -> Strands Agent
+                -> Bedrock model (converse)
+                -> @tool calls (calculator, ...)
+
+Environment variables (read once at module import):
+
+    MODEL_ARN              Bedrock foundation-model id, inference-profile ARN, or
+                           application-inference-profile ARN. Bedrock's
+                           ``converse()`` accepts all three shapes interchangeably,
+                           so one code path covers Claude / Nova / etc.
+    HONEYHIVE_API_KEY      HoneyHive project API key.
+    HONEYHIVE_PROJECT      HoneyHive project name.
+    HONEYHIVE_SERVER_URL   Optional. Self-hosted HoneyHive ingest URL.
+    HONEYHIVE_APP_URL      Optional. Used to build the session URL in the response
+                           (defaults to ``https://app.honeyhive.ai``).
+
+Returned JSON on success::
+
+    {"response": str, "session_url": str | None, "session_id": str | None}
+
+Returned JSON on failure::
+
+    {"error": str, "detail": str}
+
+Three patterns are pedagogically important — they are why the code is shaped
+the way it is, and they are worth reading before editing:
+
+1. **Cold-start init.** The tracer and agent are constructed at module import
+   time, not inside ``handler``. Lambda reuses warm containers, so warm
+   invocations skip init entirely and only pay for the agent call itself.
+2. **Session id via baggage, not the tracer singleton.** ``tracer.with_session``
+   stores ``session_id`` in OpenTelemetry baggage (a ContextVar that
+   auto-cleans on scope exit). ``tracer.session_start`` would mutate the
+   tracer singleton instead, which leaks the previous invocation's session_id
+   into the next warm invocation. Always use ``with_session`` in Lambda.
+3. **Per-invocation history reset.** Strands' ``Agent.messages`` accumulates
+   user/assistant turns. Because ``_agent`` is a module-level singleton across
+   warm invocations, invocation N would otherwise see the conversation from
+   invocations 1..N-1 — a privacy leak and an ever-growing token bill. We
+   clear ``_agent.messages`` at the top of every invocation.
 """
 
 from __future__ import annotations
 
 import os
 import uuid
+from typing import Any
 
 from honeyhive import HoneyHiveTracer
 from strands import Agent, tool
@@ -43,7 +74,7 @@ _agent: Agent | None = None
 
 @tool
 def calculator(expression: str) -> str:
-    """Evaluate a simple arithmetic expression. Exists so the trace shows an agent->tool span."""
+    """Evaluates a simple arithmetic expression and returns the result as a string."""
     allowed = set("0123456789+-*/(). ")
     if not expression or set(expression) - allowed:
         return "error: only digits and + - * / ( ) . are allowed"
@@ -57,19 +88,31 @@ def calculator(expression: str) -> str:
         return f"error: {exc}"
 
 
+# TODO: define a `current_time` @tool the agent can call. Mirror the calculator
+# above: @tool decorator, one-line docstring, no arguments, returns a str. Use
+# datetime.datetime.now(datetime.timezone.utc).isoformat() for an ISO-8601
+# timestamp that's safe across Python runtimes.
+
+
 try:
     if not HONEYHIVE_API_KEY or not HONEYHIVE_PROJECT:
         raise RuntimeError("HONEYHIVE_API_KEY and HONEYHIVE_PROJECT must be set")
     if not MODEL_ARN:
         raise RuntimeError("MODEL_ARN must be set")
 
-    tracer_kwargs = {"api_key": HONEYHIVE_API_KEY, "project": HONEYHIVE_PROJECT}
+    tracer_kwargs: dict[str, Any] = {
+        "api_key": HONEYHIVE_API_KEY,
+        "project": HONEYHIVE_PROJECT,
+    }
     if HONEYHIVE_SERVER_URL:
         tracer_kwargs["server_url"] = HONEYHIVE_SERVER_URL
     _tracer = HoneyHiveTracer.init(**tracer_kwargs)
 
     _agent = Agent(
         model=BedrockModel(model_id=MODEL_ARN),
+        # TODO: once `current_time` is defined above, register it here so the
+        # agent can pick it. Tools are passed as a list of @tool-decorated
+        # callables, e.g. `tools=[calculator, current_time]`.
         tools=[calculator],
         system_prompt="You are a concise assistant. Use the calculator tool for arithmetic.",
     )
@@ -77,20 +120,30 @@ except Exception as exc:
     _INIT_ERROR = f"{type(exc).__name__}: {exc}"
 
 
-def handler(event, context):
+def handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]:
+    """Returns the agent's response to ``event['prompt']``, wrapped in a HoneyHive session."""
     if _INIT_ERROR or _tracer is None or _agent is None:
         return {"error": "cold-start init failed", "detail": _INIT_ERROR}
 
     prompt = (event or {}).get("prompt") or "What is 17 * 23?"
     session_name = f"lambda-{uuid.uuid4().hex[:8]}"
 
-    # Reset per-invocation agent state — see module docstring, item 3(b)
+    # Clear per-invocation conversation history. Lambda reuses warm containers,
+    # and Strands' Agent.messages would otherwise carry user/assistant turns
+    # across invocations (privacy leak + ever-growing token bill).
     _agent.messages.clear()
 
     try:
+        # tracer.with_session uses OTEL baggage (a ContextVar that auto-cleans
+        # on scope exit), so session_id can't leak into the next warm
+        # invocation. Don't replace this with tracer.session_start() — that
+        # mutates the tracer singleton and bleeds across invocations.
         with _tracer.with_session(
             session_name=session_name, inputs={"prompt": prompt}
         ) as session_id:
+            # TODO: enrich the session with a custom attribute pulled from
+            # `event` (e.g. user_id) so the trace is filterable per-user in
+            # the HoneyHive UI. Use _tracer.enrich_session(metadata={...}).
             result = _agent(prompt)
             response_text = str(result)
             _tracer.enrich_session(outputs={"response": response_text})

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -1,0 +1,98 @@
+"""Strands agent on Lambda, traced via HoneyHive.
+
+Three patterns matter here; a reader poking at this later should know why:
+
+1. HoneyHive tracer + Strands agent are built at module import time so the cost
+   amortizes across Lambda container reuse. A warm invocation skips this entirely.
+2. `MODEL_ARN` is fed straight to `BedrockModel(model_id=...)`. Bedrock's
+   `converse()` accepts foundation-model IDs, regular inference-profile ARNs,
+   and application-inference-profile ARNs interchangeably, so one code path
+   handles all three shapes.
+3. Session id is attached via `tracer.with_session()` (OTEL baggage), NOT
+   `session_start()`. `session_start()` stores session_id on the tracer
+   singleton, which bleeds between invocations when Lambda reuses a container.
+   `with_session()` uses a ContextVar and cleans up on scope exit.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from honeyhive import HoneyHiveTracer
+from strands import Agent, tool
+from strands.models.bedrock import BedrockModel
+
+MODEL_ARN = os.environ.get("MODEL_ARN")
+HONEYHIVE_API_KEY = os.environ.get("HONEYHIVE_API_KEY")
+HONEYHIVE_PROJECT = os.environ.get("HONEYHIVE_PROJECT")
+HONEYHIVE_SERVER_URL = os.environ.get("HONEYHIVE_SERVER_URL")
+HONEYHIVE_APP_URL = os.environ.get("HONEYHIVE_APP_URL", "https://app.honeyhive.ai")
+
+_INIT_ERROR: str | None = None
+_tracer: HoneyHiveTracer | None = None
+_agent: Agent | None = None
+
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate a simple arithmetic expression. Exists so the trace shows an agent->tool span."""
+    allowed = set("0123456789+-*/(). ")
+    if not expression or set(expression) - allowed:
+        return "error: only digits and + - * / ( ) . are allowed"
+    try:
+        return str(eval(expression, {"__builtins__": {}}, {}))  # noqa: S307 — input is whitelisted above
+    except Exception as exc:
+        return f"error: {exc}"
+
+
+try:
+    if not HONEYHIVE_API_KEY or not HONEYHIVE_PROJECT:
+        raise RuntimeError("HONEYHIVE_API_KEY and HONEYHIVE_PROJECT must be set")
+    if not MODEL_ARN:
+        raise RuntimeError("MODEL_ARN must be set")
+
+    tracer_kwargs = {"api_key": HONEYHIVE_API_KEY, "project": HONEYHIVE_PROJECT}
+    if HONEYHIVE_SERVER_URL:
+        tracer_kwargs["server_url"] = HONEYHIVE_SERVER_URL
+    _tracer = HoneyHiveTracer.init(**tracer_kwargs)
+
+    _agent = Agent(
+        model=BedrockModel(model_id=MODEL_ARN),
+        tools=[calculator],
+        system_prompt="You are a concise assistant. Use the calculator tool for arithmetic.",
+    )
+except Exception as exc:
+    _INIT_ERROR = f"{type(exc).__name__}: {exc}"
+
+
+def handler(event, context):
+    if _INIT_ERROR or _tracer is None or _agent is None:
+        return {"error": "cold-start init failed", "detail": _INIT_ERROR}
+
+    prompt = (event or {}).get("prompt") or "What is 17 * 23?"
+    session_name = f"lambda-{uuid.uuid4().hex[:8]}"
+
+    try:
+        with _tracer.with_session(
+            session_name=session_name, inputs={"prompt": prompt}
+        ) as session_id:
+            result = _agent(prompt)
+            response_text = str(result)
+            _tracer.enrich_session(outputs={"response": response_text})
+    except Exception as exc:
+        return {
+            "error": "agent invocation failed",
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+
+    session_url = (
+        f"{HONEYHIVE_APP_URL}/{HONEYHIVE_PROJECT}/sessions/{session_id}"
+        if session_id
+        else None
+    )
+    return {
+        "response": response_text,
+        "session_url": session_url,
+        "session_id": session_id,
+    }

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -40,6 +40,10 @@ def calculator(expression: str) -> str:
     allowed = set("0123456789+-*/(). ")
     if not expression or set(expression) - allowed:
         return "error: only digits and + - * / ( ) . are allowed"
+    # Reject `**` — the char allowlist permits `*`, so `9**9**9` would slip through
+    # and exhaust CPU/memory inside eval. Demo tool doesn't need exponentiation.
+    if "**" in expression:
+        return "error: exponentiation not allowed"
     try:
         return str(eval(expression, {"__builtins__": {}}, {}))  # noqa: S307 — input is whitelisted above
     except Exception as exc:

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -8,10 +8,17 @@ Three patterns matter here; a reader poking at this later should know why:
    `converse()` accepts foundation-model IDs, regular inference-profile ARNs,
    and application-inference-profile ARNs interchangeably, so one code path
    handles all three shapes.
-3. Session id is attached via `tracer.with_session()` (OTEL baggage), NOT
-   `session_start()`. `session_start()` stores session_id on the tracer
-   singleton, which bleeds between invocations when Lambda reuses a container.
-   `with_session()` uses a ContextVar and cleans up on scope exit.
+3. Per-invocation state must be reset — two things bleed across container reuse
+   if you're not careful:
+   (a) session id: use `tracer.with_session()` (OTEL baggage, ContextVar-based,
+       auto-cleanup on scope exit), NOT `session_start()` which stores on the
+       tracer singleton. This is the rc10 fix from customer-nationwide
+       2025-10-28.
+   (b) agent conversation history: the Strands `Agent` accumulates user and
+       assistant turns in `self.messages`. Since `_agent` is the same singleton
+       across warm invocations, invocation N would otherwise see the full
+       history from invocations 1..N-1 — a privacy leak and an ever-growing
+       token bill. Clear `_agent.messages` at the start of each invocation.
 """
 
 from __future__ import annotations
@@ -76,6 +83,9 @@ def handler(event, context):
 
     prompt = (event or {}).get("prompt") or "What is 17 * 23?"
     session_name = f"lambda-{uuid.uuid4().hex[:8]}"
+
+    # Reset per-invocation agent state — see module docstring, item 3(b)
+    _agent.messages.clear()
 
     try:
         with _tracer.with_session(

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
@@ -1,0 +1,6 @@
+# Lambda runtime deps — bundled into the Lambda deployment package by CDK.
+# Keep this separate from the repo-root requirements.txt, which is CDK-synth deps only.
+
+strands-agents>=1.0.0,<2.0.0
+honeyhive>=1.0.0rc20  # Pin to be tightened in HHAI-4970 once the rc with Strands event_type priority lands
+boto3>=1.34.0


### PR DESCRIPTION
## Summary

- Adds `lambda/handler.py`: a minimal Strands agent on Lambda, traced via HoneyHive
- Adds `lambda/requirements.txt`: Lambda-bundled runtime deps (kept separate from the CDK-synth `requirements.txt` at the repo root)

Stacked on `hhai-4966-cdk-scaffold` (PR #30). When that merges, rebase this onto `main`.

## Why these patterns

1. **Cold-start init.** Tracer + agent are built at module import time so Lambda container reuse amortizes the cost. A warm invocation skips init entirely.
2. **`MODEL_ARN` goes straight to `BedrockModel(model_id=...)`.** Bedrock's `converse()` transparently accepts foundation-model IDs, inference-profile ARNs, and application-inference-profile ARNs. One code path covers NW's Claude 4.5 Sonnet / Nova (app-inf-profile) and Claude 3.x (inf-profile) without branching.
3. **Session id via `tracer.with_session()` — NOT `session_start()`.** This is the rc10 fix pattern surfaced by customer-nationwide on 2025-10-28. `session_start()` stores session_id on the tracer singleton, which bleeds between invocations when Lambda reuses a container. `with_session()` uses OpenTelemetry baggage (ContextVar-based) and cleans up on scope exit — no bleed possible.
4. **Graceful cold-start failure.** Top-level init is wrapped in try/except. If `MODEL_ARN`, `HONEYHIVE_API_KEY`, or `HONEYHIVE_PROJECT` are missing (or HoneyHive init fails for any reason), the module still imports cleanly and the handler returns a descriptive error JSON on invocation instead of crashing the Lambda.

## Handler shape

Return JSON:
```json
{"response": "...", "session_url": "https://app.honeyhive.ai/<project>/sessions/<uuid>", "session_id": "<uuid>"}
```

Error JSON on failure:
```json
{"error": "cold-start init failed", "detail": "RuntimeError: MODEL_ARN must be set"}
```

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `ci-check-local.sh` passes
- [x] Module imports cleanly with no env vars set (returns error JSON on invocation)
- [x] Module imports cleanly with partial env vars (error JSON identifies which var is missing)
- [ ] End-to-end smoke test via CDK deploy — blocked on HHAI-4968 (stack) and HHAI-4972 (NW env config). Maintainer should wait for those before verifying in AWS.

## Related

- Blocks HHAI-4968 (stack), HHAI-4969 (README), HHAI-4970 (version pin), HHAI-4971 (curl smoke test)
- `honeyhive` pin is deliberately permissive here (`>=1.0.0rc20`); HHAI-4970 tightens it to the rc that contains hive-kube #3239 (Strands event_type priority fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)