### PR TITLE
HHAI-4970: pin honeyhive SDK versions for Strands + app-inference-profile

### DIFF
--- a/strands-bedrock-lambda-cdk-cookbook/README.md
+++ b/strands-bedrock-lambda-cdk-cookbook/README.md
@@ -17,3 +17,7 @@ npx --yes cdk synth
 ```
 
 `cdk synth` emits CloudFormation to `cdk.out/`. The stack currently synthesizes empty; resources land in follow-up PRs.
+
+## Version pins
+
+`lambda/requirements.txt` uses exact pins — reproducibility over flexibility. The HoneyHive SDK is pinned to `1.0.0rc21` because it's the earliest rc with both the session_id baggage isolation (prevents warm-Lambda session bleed across users) and the event_type priority detection that routes Strands GenAI ops (`invoke_agent` → chain, `execute_tool` → tool, `chat` → model) instead of falling through to the generic `tool` default. See the header of `lambda/requirements.txt` for the full rationale.

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -23,6 +23,7 @@ Three patterns matter here; a reader poking at this later should know why:
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 
@@ -81,7 +82,18 @@ def handler(event, context):
     if _INIT_ERROR or _tracer is None or _agent is None:
         return {"error": "cold-start init failed", "detail": _INIT_ERROR}
 
-    prompt = (event or {}).get("prompt") or "What is 17 * 23?"
+    # HTTP API v2 delivers the POST body as a JSON string in event["body"];
+    # direct Lambda invokes put keys at the event root. Support both.
+    event = event or {}
+    body_raw = event.get("body")
+    if isinstance(body_raw, str) and body_raw:
+        try:
+            body = json.loads(body_raw)
+        except json.JSONDecodeError:
+            body = {}
+    else:
+        body = {}
+    prompt = body.get("prompt") or event.get("prompt") or "What is 17 * 23?"
     session_name = f"lambda-{uuid.uuid4().hex[:8]}"
 
     # Reset per-invocation agent state — see module docstring, item 3(b)

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
@@ -1,6 +1,29 @@
 # Lambda runtime deps — bundled into the Lambda deployment package by CDK.
 # Keep this separate from the repo-root requirements.txt, which is CDK-synth deps only.
+#
+# Exact pins (HHAI-4970). This is a hackathon template — reproducibility matters
+# more than flexibility. Why these versions:
+#
+#   honeyhive==1.0.0rc21
+#     - session_id baggage isolation (rc10+): get_baggage("honeyhive.session_id")
+#       in tracer/core/operations.py prevents warm-Lambda session bleed across
+#       users (customer-nationwide, 2025-10-28).
+#     - event_type priority detection in HoneyHiveSpanProcessor: raw >
+#       honeyhive_event_type > gen_ai.operation.name > openinference.span.kind >
+#       span-name patterns. Maps Strands GenAI ops (invoke_agent → chain,
+#       execute_tool → tool, chat → model) so Strands spans are categorized
+#       correctly instead of falling through to the default "tool". SDK-side
+#       complement to hive-kube#3239.
+#     - application-inference-profile ARNs: handled transparently by boto3 +
+#       Bedrock converse(); no SDK-side change needed.
+#
+#   strands-agents==1.26.0
+#     Version the handler was authored/tested against.
+#
+#   boto3==1.42.47
+#     Pinned for reproducibility. Lambda runtime provides its own boto3, but an
+#     exact pin keeps the deployed layer deterministic.
 
-strands-agents>=1.0.0,<2.0.0
-honeyhive>=1.0.0rc20  # Pin to be tightened in HHAI-4970 once the rc with Strands event_type priority lands
-boto3>=1.34.0
+honeyhive==1.0.0rc21
+strands-agents==1.26.0
+boto3==1.42.47


### PR DESCRIPTION
## Summary
- Pin `honeyhive==1.0.0rc21` — earliest rc with session_id baggage isolation (prevents warm-Lambda session bleed across users, from customer-nationwide 2025-10-28) and event_type priority detection that maps Strands GenAI ops (`invoke_agent`→chain, `execute_tool`→tool, `chat`→model) instead of defaulting to generic `tool`. SDK-side complement to hive-kube#3239.
- Pin `strands-agents==1.26.0` (version the handler was authored/tested against) and `boto3==1.42.47` for reproducibility.
- Application-inference-profile ARN support requires no SDK pin — `BedrockModel(model_id=ARN)` forwards verbatim to boto3 `converse()`, which accepts foundation IDs, inference-profile ARNs, and application-inference-profile ARNs interchangeably.
- Document the rationale in the `lambda/requirements.txt` header + a short README section.

Base branch is `hhai-4967-lambda-handler`. Stack: main ← #30 (scaffold) ← #32 (handler) ← this PR. Rebases onto main trivially when #30 and #32 land.

Note: the commit `11f20b9 HHAI-4969: parse prompt from HTTP API v2 body` is a legitimate fix that was cherry-picked onto this branch in the shared workspace before my work landed; leaving it in place since it's a real bug fix and blocking it out would require a force-push rebase. If you'd rather land it through a separate PR, let me know and I'll rebase.

## Test plan
- [x] `pip install -r lambda/requirements.txt` in a fresh venv succeeds without resolution errors
- [x] `python3 -c "import honeyhive; print(honeyhive.__version__)"` → `1.0.0rc21`
- [x] `handler.py` imports cleanly against the pinned SDK
- [x] `ruff check` + `ruff format --check` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)