### PR TITLE
feat: add Cursor SDK HoneyHive tracing cookbook

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "honeyhive-docs": {
+      "url": "https://docs.honeyhive.ai/mcp"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,16 @@
 # testing
 /coverage
 
+# python
+google-adk-cookbook/__pycache__/
+
 # next.js
 **/.next/**
 **/out/**
 
 # production
 /build
+**/dist
 
 # misc
 .DS_Store
@@ -36,6 +40,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!**/.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Integration examples for AI observability and evaluation with HoneyHive.
 |----------|-------------|
 | [wealth-management-agent](./wealth-management-agent) | Multi-agent wealth advisory platform with HoneyHive tracing (CrewAI) |
 
+### Agent SDK Integrations
+
+| Cookbook | Description |
+|----------|-------------|
+| [cursor-sdk-honeyhive](./cursor-sdk-honeyhive) | HoneyHive tracing for Cursor SDK agent runs and tool calls |
+
 ### RAG & Vector Databases
 
 | Cookbook | Description |

--- a/cursor-sdk-honeyhive/.env.example
+++ b/cursor-sdk-honeyhive/.env.example
@@ -1,0 +1,10 @@
+CURSOR_API_KEY=
+HH_API_KEY=
+HH_PROJECT=Cursor SDK HoneyHive Demo
+
+# Optional: override the default Cursor model or source label.
+CURSOR_MODEL=composer-2
+HH_SOURCE=cursor-sdk-honeyhive
+
+# Optional: use a self-hosted or dedicated HoneyHive API endpoint.
+HH_API_URL=https://api.honeyhive.ai

--- a/cursor-sdk-honeyhive/README.md
+++ b/cursor-sdk-honeyhive/README.md
@@ -2,6 +2,8 @@
 
 Trace [Cursor SDK](https://cursor.com/docs/sdk/typescript) agent runs in [HoneyHive](https://honeyhive.ai). This cookbook hooks Cursor's documented streaming, `onDelta`, `onStep`, `wait()`, and `conversation()` surfaces and exports each run as a HoneyHive trace using `@honeyhive/api-client`.
 
+> **Note:** Cursor's TypeScript SDK is currently in public beta. Treat this cookbook as an experimental example and expect SDK APIs to evolve.
+
 One Cursor run becomes a HoneyHive session containing:
 
 - a top-level `session.start` event
@@ -68,7 +70,7 @@ Each Cursor run produces one HoneyHive session with the following events:
 | Event           | Type    | Notes                                                                                                                                                                                           |
 | --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `session.start` | session | Top-level container with prompt, workspace, status, and the SDK tag (`sdk: cursor`).                                                                                                            |
-| `agent.run`     | chain   | Cursor SDK invocation. Inputs: prompt + workspace. Outputs: status, result, accumulated thinking. Metadata includes IDs, Git data, stream/delta summaries, token usage, step counts, and conversation shape. |
+| `agent.run`     | chain   | Cursor SDK invocation. Inputs: prompt + workspace. Outputs: status, result, accumulated thinking. Metadata includes IDs, Git data, stream/delta summaries, step counts, and conversation shape. |
 | `tool.<name>`   | tool    | One per Cursor [tool call](https://cursor.com/docs/sdk/typescript) (`shell`, `edit`, `read`, `write`, `grep`, `mcp`, etc.). Captures args, result, status, and execution time.                  |
 | `turn.agent`    | model   | Final model turn — prompt + response text, tagged with `gen_ai.system: cursor`.                                                                                                                 |
 

--- a/cursor-sdk-honeyhive/README.md
+++ b/cursor-sdk-honeyhive/README.md
@@ -1,0 +1,82 @@
+# Cursor SDK HoneyHive Tracing Cookbook
+
+Trace a Cursor SDK agent run in HoneyHive. This example uses the Cursor TypeScript SDK `onStep` callback and the public HoneyHive TypeScript client to turn one agent run into a HoneyHive trace with a session event, an agent event, tool events, and a final turn event.
+
+## What This Shows
+
+- Create a local Cursor SDK agent from TypeScript.
+- Capture Cursor tool calls as HoneyHive trace events.
+- Export the trace through `@honeyhive/api-client`.
+- Print Cursor and HoneyHive IDs for the exported run.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm
+- A Cursor API key
+- A HoneyHive API key
+
+## Setup
+
+```bash
+cd cursor-sdk-honeyhive
+pnpm install
+cp .env.example .env
+```
+
+Fill in `.env`:
+
+```bash
+CURSOR_API_KEY=your_cursor_api_key
+HH_API_KEY=your_honeyhive_api_key
+```
+
+Optional settings:
+
+- `HH_PROJECT` sets a project label in trace metadata.
+- `HH_API_URL` points at a self-hosted or dedicated HoneyHive API endpoint.
+- `CURSOR_MODEL` defaults to `composer-2`.
+
+## Run
+
+```bash
+pnpm start
+```
+
+The default prompt asks Cursor to read this README and summarize the example without modifying files. After the run finishes, the script exports spans to HoneyHive and prints metadata like:
+
+```json
+{
+  "cursorAgentId": "agent-id",
+  "cursorRunId": "run-id",
+  "cursorStatus": "finished",
+  "honeyhiveSessionId": "session-id",
+  "honeyhiveEventId": "event-id"
+}
+```
+
+## Trace Shape
+
+The exported trace uses HoneyHive event metadata and GenAI semantic attributes. By default, the instrumentor redacts common secret fields, truncates large payloads, and stores only the workspace folder name instead of the full local path.
+
+- `session.start`: top-level HoneyHive session event.
+- `agent.run`: Cursor SDK agent invocation with prompt, result, model, Git metadata, and step counts.
+- `tool.<name>`: one event per Cursor SDK tool call observed through `onStep`.
+- `turn.agent`: final model turn with prompt and response text.
+
+## Adapting This Example
+
+Use this cookbook as a starting point for tracing longer Cursor SDK workflows. The reusable code lives in `instrumentor/` and is exported from `instrumentor/index.ts`:
+
+```typescript
+import { HoneyHiveCursorInstrumentor } from './instrumentor/index.js';
+```
+
+This directory is intentionally shaped like a future package entrypoint, while `index.ts` remains the runnable cookbook example. To customize what gets sent to HoneyHive, pass a `sanitize` function to `HoneyHiveCursorInstrumentor`.
+
+To verify the package entrypoint locally:
+
+```bash
+pnpm build
+```
+

--- a/cursor-sdk-honeyhive/README.md
+++ b/cursor-sdk-honeyhive/README.md
@@ -1,20 +1,26 @@
-# Cursor SDK HoneyHive Tracing Cookbook
+# Cursor SDK × HoneyHive
 
-Trace a Cursor SDK agent run in HoneyHive. This example uses the Cursor TypeScript SDK `onStep` callback and the public HoneyHive TypeScript client to turn one agent run into a HoneyHive trace with a session event, an agent event, tool events, and a final turn event.
+Trace [Cursor SDK](https://cursor.com/docs/sdk/typescript) agent runs in [HoneyHive](https://honeyhive.ai). This cookbook hooks Cursor's `onStep` callback and exports each run as a HoneyHive trace using the `[@honeyhive/api-client](https://www.npmjs.com/package/@honeyhive/api-client)`.
 
-## What This Shows
+One Cursor run becomes a HoneyHive session containing:
 
-- Create a local Cursor SDK agent from TypeScript.
-- Capture Cursor tool calls as HoneyHive trace events.
-- Export the trace through `@honeyhive/api-client`.
-- Print Cursor and HoneyHive IDs for the exported run.
+- a top-level `session.start` event
+- an `agent.run` chain event with the prompt, result, model, Git metadata, and step counts
+- one `tool.<name>` event per Cursor tool call, with args, result, and execution time
+- a final `turn.agent` event with the assistant's response
+
+The instrumentor redacts common secret fields, truncates large payloads, and stores only the workspace folder name instead of the full local path.
 
 ## Prerequisites
 
-- Node.js 20+
-- pnpm
-- A Cursor API key
-- A HoneyHive API key
+
+| Requirement       | Where to get it                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| Node.js 20+       | [nodejs.org](https://nodejs.org)                                                     |
+| pnpm              | [pnpm.io/installation](https://pnpm.io/installation)                                 |
+| Cursor API key    | [Cursor Dashboard → Integrations](https://cursor.com/dashboard/integrations)         |
+| HoneyHive API key | [HoneyHive Dashboard](https://app.honeyhive.ai) (or [sign up](https://honeyhive.ai)) |
+
 
 ## Setup
 
@@ -31,11 +37,20 @@ CURSOR_API_KEY=your_cursor_api_key
 HH_API_KEY=your_honeyhive_api_key
 ```
 
-Optional settings:
+### Environment variables
 
-- `HH_PROJECT` sets a project label in trace metadata.
-- `HH_API_URL` points at a self-hosted or dedicated HoneyHive API endpoint.
-- `CURSOR_MODEL` defaults to `composer-2`.
+
+| Variable               | Required | Default                     | Description                                                           |
+| ---------------------- | -------- | --------------------------- | --------------------------------------------------------------------- |
+| `CURSOR_API_KEY`       | Yes      | –                           | Cursor user or service account API key                                |
+| `HH_API_KEY`           | Yes      | –                           | HoneyHive API key                                                     |
+| `HH_PROJECT`           | No       | `Cursor SDK HoneyHive Demo` | Project label written to event metadata                               |
+| `HH_SOURCE`            | No       | `cursor-sdk-honeyhive`      | `source` field on every exported event                                |
+| `HH_API_URL`           | No       | `https://api.honeyhive.ai`  | HoneyHive API endpoint (set for self-hosted or dedicated deployments) |
+| `CURSOR_MODEL`         | No       | `composer-2`                | Cursor model id passed to `Agent.create`                              |
+| `CURSOR_PROMPT`        | No       | *summarize this README*     | Prompt sent to the agent                                              |
+| `CURSOR_WORKSPACE_DIR` | No       | `process.cwd()`             | Working directory for the local Cursor agent                          |
+
 
 ## Run
 
@@ -43,40 +58,84 @@ Optional settings:
 pnpm start
 ```
 
-The default prompt asks Cursor to read this README and summarize the example without modifying files. After the run finishes, the script exports spans to HoneyHive and prints metadata like:
+The default prompt asks Cursor to read `README.md` and summarize this example without modifying files. Once the run finishes, open the [HoneyHive Log Store](https://docs.honeyhive.ai/v2/tracing/ui-flows) to view the trace.
 
-```json
-{
-  "cursorAgentId": "agent-id",
-  "cursorRunId": "run-id",
-  "cursorStatus": "finished",
-  "honeyhiveSessionId": "session-id",
-  "honeyhiveEventId": "event-id"
-}
-```
+## Trace shape
 
-## Trace Shape
+Each Cursor run produces one HoneyHive session with the following events:
 
-The exported trace uses HoneyHive event metadata and GenAI semantic attributes. By default, the instrumentor redacts common secret fields, truncates large payloads, and stores only the workspace folder name instead of the full local path.
 
-- `session.start`: top-level HoneyHive session event.
-- `agent.run`: Cursor SDK agent invocation with prompt, result, model, Git metadata, and step counts.
-- `tool.<name>`: one event per Cursor SDK tool call observed through `onStep`.
-- `turn.agent`: final model turn with prompt and response text.
+| Event           | Type    | Notes                                                                                                                                                                                           |
+| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session.start` | session | Top-level container with prompt, workspace, status, and the SDK tag (`sdk: cursor`).                                                                                                            |
+| `agent.run`     | chain   | Cursor SDK invocation. Inputs: prompt + workspace. Outputs: status, result, accumulated thinking. Metadata includes `cursor.agent_id`, `cursor.run_id`, `cursor.git`, and `cursor.step_counts`. |
+| `tool.<name>`   | tool    | One per Cursor [tool call](https://cursor.com/docs/sdk/typescript) (`shell`, `edit`, `read`, `write`, `grep`, `mcp`, etc.). Captures args, result, status, and execution time.                  |
+| `turn.agent`    | model   | Final model turn — prompt + response text, tagged with `gen_ai.system: cursor`.                                                                                                                 |
 
-## Adapting This Example
 
-Use this cookbook as a starting point for tracing longer Cursor SDK workflows. The reusable code lives in `instrumentor/` and is exported from `instrumentor/index.ts`:
+Tool, agent, and model events use [GenAI semantic attributes](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`) so they line up with HoneyHive's standard views.
+
+## How it works
+
+The reusable code lives in `[instrumentor/](./instrumentor)` and is exported from `[instrumentor/index.ts](./instrumentor/index.ts)`:
 
 ```typescript
 import { HoneyHiveCursorInstrumentor } from './instrumentor/index.js';
+
+const instrumentor = new HoneyHiveCursorInstrumentor({
+  apiKey: process.env.HH_API_KEY,
+  project: 'My Cursor Project',
+});
+
+const result = await instrumentor.traceRun({
+  agent,
+  message: 'Run the test suite and fix any failing tests',
+});
 ```
 
-This directory is intentionally shaped like a future package entrypoint, while `index.ts` remains the runnable cookbook example. To customize what gets sent to HoneyHive, pass a `sanitize` function to `HoneyHiveCursorInstrumentor`.
+`traceRun` subscribes to the Cursor SDK `[onStep` callback]([https://cursor.com/docs/sdk/typescript](https://cursor.com/docs/sdk/typescript)), buffers tool calls, awaits `run.wait()`, then exports the full trace through `@honeyhive/api-client`'s `sessions.start` and `sessions.addTraces` APIs.
 
-To verify the package entrypoint locally:
+### Customizing what gets sent
+
+Pass a `sanitize` function to scrub or rewrite anything before it leaves your process:
+
+```typescript
+const instrumentor = new HoneyHiveCursorInstrumentor({
+  apiKey: process.env.HH_API_KEY,
+  sanitize: (value, context) => {
+    if (context === 'toolArgs') {
+      return scrubPii(value);
+    }
+    return value;
+  },
+});
+```
+
+Sanitize contexts: `prompt`, `result`, `thinking`, `toolArgs`, `toolResult`, `metadata`, `workspace`. The default sanitizer redacts keys matching `api[_-]?key|authorization|cookie|credential|password|secret|token` and truncates strings over 4 KB.
+
+## Adapting this example
+
+This directory is shaped like a future package entrypoint, while `[index.ts](./index.ts)` stays the runnable cookbook. Common extensions:
+
+- Swap `local: { cwd }` for a Cursor [cloud runtime](https://cursor.com/docs/sdk/typescript) to trace cloud agent runs the same way.
+- Wrap a long-running script that calls `agent.send()` multiple times, reusing one `traceRun` per prompt.
+- Pipe additional metadata (PR number, CI run id, user id) by extending `traceRun` with extra `metadata` fields on the events.
+
+## Development
+
+Type-check and build the instrumentor as a standalone package:
 
 ```bash
+pnpm typecheck
 pnpm build
 ```
+
+## Links
+
+- [Cursor TypeScript SDK docs](https://cursor.com/docs/sdk/typescript)
+- [Cursor APIs overview](https://cursor.com/docs/api)
+- `[@cursor/sdk` on npm]([https://www.npmjs.com/package/@cursor/sdk](https://www.npmjs.com/package/@cursor/sdk))
+- [HoneyHive docs (v2)](https://docs.honeyhive.ai/v2/introduction/tracing-quickstart)
+- `[@honeyhive/api-client` on npm]([https://www.npmjs.com/package/@honeyhive/api-client](https://www.npmjs.com/package/@honeyhive/api-client))
+- [More HoneyHive cookbooks](../README.md)
 

--- a/cursor-sdk-honeyhive/README.md
+++ b/cursor-sdk-honeyhive/README.md
@@ -1,11 +1,11 @@
 # Cursor SDK × HoneyHive
 
-Trace [Cursor SDK](https://cursor.com/docs/sdk/typescript) agent runs in [HoneyHive](https://honeyhive.ai). This cookbook hooks Cursor's `onStep` callback and exports each run as a HoneyHive trace using the `[@honeyhive/api-client](https://www.npmjs.com/package/@honeyhive/api-client)`.
+Trace [Cursor SDK](https://cursor.com/docs/sdk/typescript) agent runs in [HoneyHive](https://honeyhive.ai). This cookbook hooks Cursor's documented streaming, `onDelta`, `onStep`, `wait()`, and `conversation()` surfaces and exports each run as a HoneyHive trace using `@honeyhive/api-client`.
 
 One Cursor run becomes a HoneyHive session containing:
 
 - a top-level `session.start` event
-- an `agent.run` chain event with the prompt, result, model, Git metadata, and step counts
+- an `agent.run` chain event with the prompt, result, model, Git metadata, stream summary, delta summary, step timing, step counts, and conversation summary
 - one `tool.<name>` event per Cursor tool call, with args, result, and execution time
 - a final `turn.agent` event with the assistant's response
 
@@ -68,7 +68,7 @@ Each Cursor run produces one HoneyHive session with the following events:
 | Event           | Type    | Notes                                                                                                                                                                                           |
 | --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `session.start` | session | Top-level container with prompt, workspace, status, and the SDK tag (`sdk: cursor`).                                                                                                            |
-| `agent.run`     | chain   | Cursor SDK invocation. Inputs: prompt + workspace. Outputs: status, result, accumulated thinking. Metadata includes `cursor.agent_id`, `cursor.run_id`, `cursor.git`, and `cursor.step_counts`. |
+| `agent.run`     | chain   | Cursor SDK invocation. Inputs: prompt + workspace. Outputs: status, result, accumulated thinking. Metadata includes IDs, Git data, stream/delta summaries, token usage, step counts, and conversation shape. |
 | `tool.<name>`   | tool    | One per Cursor [tool call](https://cursor.com/docs/sdk/typescript) (`shell`, `edit`, `read`, `write`, `grep`, `mcp`, etc.). Captures args, result, status, and execution time.                  |
 | `turn.agent`    | model   | Final model turn — prompt + response text, tagged with `gen_ai.system: cursor`.                                                                                                                 |
 
@@ -93,7 +93,7 @@ const result = await instrumentor.traceRun({
 });
 ```
 
-`traceRun` subscribes to the Cursor SDK `[onStep` callback]([https://cursor.com/docs/sdk/typescript](https://cursor.com/docs/sdk/typescript)), buffers tool calls, awaits `run.wait()`, then exports the full trace through `@honeyhive/api-client`'s `sessions.start` and `sessions.addTraces` APIs.
+`traceRun` composes Cursor SDK `onDelta`, `onStep`, `run.stream()`, `run.wait()`, and `run.conversation()` to capture tool calls, stream status, token usage, step timing, and final run metadata. It then exports the trace through `@honeyhive/api-client`'s `sessions.start` and `sessions.addTraces` APIs.
 
 ### Customizing what gets sent
 

--- a/cursor-sdk-honeyhive/index.ts
+++ b/cursor-sdk-honeyhive/index.ts
@@ -1,0 +1,47 @@
+import 'dotenv/config';
+
+import { Agent } from '@cursor/sdk';
+
+import { HoneyHiveCursorInstrumentor } from './instrumentor/index.js';
+
+const cursorApiKey = readRequiredEnv('CURSOR_API_KEY');
+const honeyHiveApiKey = readRequiredEnv('HH_API_KEY');
+const model = process.env.CURSOR_MODEL || 'composer-2';
+const workspaceDir = process.env.CURSOR_WORKSPACE_DIR || process.cwd();
+
+const instrumentor = new HoneyHiveCursorInstrumentor({
+  apiKey: honeyHiveApiKey,
+  project: process.env.HH_PROJECT || 'Cursor SDK HoneyHive Demo',
+  source: process.env.HH_SOURCE || 'cursor-sdk-honeyhive',
+});
+
+const agent = await Agent.create({
+  apiKey: cursorApiKey,
+  model: { id: model },
+  local: { cwd: workspaceDir },
+});
+
+try {
+  const result = await instrumentor.traceRun({
+    agent,
+    message:
+      process.env.CURSOR_PROMPT ||
+      'Read README.md in this repository, then summarize what this Cursor SDK HoneyHive example does in one sentence. Do not modify files.',
+    sessionName: 'Cursor SDK HoneyHive Demo',
+    model,
+    cwd: workspaceDir,
+  });
+
+  console.log('Exported Cursor SDK trace to HoneyHive:');
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  await agent[Symbol.asyncDispose]();
+}
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}

--- a/cursor-sdk-honeyhive/index.ts
+++ b/cursor-sdk-honeyhive/index.ts
@@ -21,6 +21,8 @@ const agent = await Agent.create({
   local: { cwd: workspaceDir },
 });
 
+console.log(`→ Starting Cursor agent (${model}) in ${workspaceDir}`);
+
 try {
   const result = await instrumentor.traceRun({
     agent,
@@ -30,9 +32,19 @@ try {
     sessionName: 'Cursor SDK HoneyHive Demo',
     model,
     cwd: workspaceDir,
+    onStep: (step) => {
+      switch (step.type) {
+        case 'toolCall':
+          console.log(`  • tool: ${step.message.type}`);
+          break;
+        case 'thinkingMessage':
+        case 'assistantMessage':
+          break;
+      }
+    },
   });
 
-  console.log('Exported Cursor SDK trace to HoneyHive:');
+  console.log('← Exported Cursor SDK trace to HoneyHive:');
   console.log(JSON.stringify(result, null, 2));
 } finally {
   await agent[Symbol.asyncDispose]();

--- a/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
+++ b/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
@@ -1,12 +1,22 @@
 import crypto from 'node:crypto';
 
-import { type RunResultStatus } from '@cursor/sdk';
+import {
+  type ConversationTurn,
+  type InteractionUpdate,
+  type ModelSelection,
+  type RunResultStatus,
+  type SDKMessage,
+} from '@cursor/sdk';
 import { Client, type StartSessionResponse } from '@honeyhive/api-client';
 
 import { createClientConfig } from './config.js';
 import { createAgentEvent, createFinalEvent, createToolEvent } from './events.js';
 import {
+  type CursorConversationSummary,
+  type CursorDeltaSummary,
+  type CursorMessageInput,
   type CursorRunGit,
+  type CursorStreamSummary,
   type HoneyHiveSanitizer,
   type HoneyHiveCursorInstrumentorOptions,
   type HoneyHiveTraceEvent,
@@ -44,9 +54,21 @@ export class HoneyHiveCursorInstrumentor {
     let thinkingText = '';
     const stepCounts: Record<string, number> = {};
     const toolEvents: HoneyHiveTraceEvent[] = [];
+    const deltaSummary = createDeltaSummary();
+    const streamSummary = createStreamSummary();
+    let streamError: string | undefined;
+    let conversationSummary: CursorConversationSummary | undefined;
+    let conversationError: string | undefined;
+    const promptText = messageText(options.message);
+    let resolvedModel = options.model ?? modelSelectionName(options.sendOptions?.model);
 
     try {
       const run = await options.agent.send(options.message, {
+        ...options.sendOptions,
+        onDelta: async ({ update }) => {
+          recordDelta(deltaSummary, update);
+          await options.onDelta?.(update);
+        },
         onStep: async ({ step }) => {
           stepCounts[step.type] = (stepCounts[step.type] ?? 0) + 1;
 
@@ -82,11 +104,38 @@ export class HoneyHiveCursorInstrumentor {
       });
       cursorRunId = run.id;
 
+      if (run.supports('stream')) {
+        try {
+          for await (const event of run.stream()) {
+            recordStream(streamSummary, event);
+            if (event.type === 'system') {
+              resolvedModel = modelSelectionName(event.model) ?? resolvedModel;
+            }
+            await options.onStream?.(event);
+          }
+        } catch (caught) {
+          streamError = formatError(caught);
+        }
+      } else {
+        streamError = run.unsupportedReason('stream');
+      }
+
       const result = await run.wait();
       status = result.status;
       resultText = result.result;
       durationMs = result.durationMs;
       git = result.git;
+      resolvedModel = modelSelectionName(result.model) ?? resolvedModel;
+
+      if (run.supports('conversation')) {
+        try {
+          conversationSummary = summarizeConversation(await run.conversation());
+        } catch (caught) {
+          conversationError = formatError(caught);
+        }
+      } else {
+        conversationError = run.unsupportedReason('conversation');
+      }
     } catch (caught) {
       error = formatError(caught);
       status = 'error';
@@ -94,19 +143,23 @@ export class HoneyHiveCursorInstrumentor {
 
     const endTime = Date.now();
     const result = resultText ?? finalAssistantText;
+    const agentChildrenIds = [
+      ...toolEvents.map((event) => event.event_id).filter(isString),
+      finalEventId,
+    ];
     const exportedEvents = [
       createAgentEvent({
         eventId: agentEventId,
         sessionId,
         parentId: sessionId,
-        childrenIds: toolEvents.map((event) => event.event_id).filter(isString),
+        childrenIds: agentChildrenIds,
         project: this.#project,
         source: this.#source,
         agentId: options.agent.agentId,
         runId: cursorRunId,
-        model: options.model,
+        model: resolvedModel,
         cwd: options.cwd,
-        prompt: options.message,
+        prompt: promptText,
         result,
         status,
         error,
@@ -115,6 +168,11 @@ export class HoneyHiveCursorInstrumentor {
         durationMs,
         git,
         stepCounts,
+        deltaSummary,
+        streamSummary,
+        streamError,
+        conversationSummary,
+        conversationError,
         thinkingText,
         sanitize: this.#sanitize,
       }),
@@ -122,15 +180,17 @@ export class HoneyHiveCursorInstrumentor {
       createFinalEvent({
         eventId: finalEventId,
         sessionId,
-        parentId: sessionId,
+        parentId: agentEventId,
         project: this.#project,
         source: this.#source,
-        model: options.model,
-        prompt: options.message,
+        model: resolvedModel,
+        prompt: promptText,
         result,
         status,
         error,
+        startTime: deltaSummary.responseStartTime ?? endTime,
         endTime,
+        usage: deltaSummary.usage,
         sanitize: this.#sanitize,
       }),
     ];
@@ -138,14 +198,16 @@ export class HoneyHiveCursorInstrumentor {
     const session = await this.#startSession({
       sessionId,
       sessionName: options.sessionName ?? 'Cursor SDK HoneyHive Demo',
-      prompt: options.message,
+      prompt: promptText,
       cwd: options.cwd,
       result,
       status,
       error,
       startTime,
       endTime,
-      childrenIds: [agentEventId, finalEventId],
+      childrenIds: [agentEventId],
+      usage: deltaSummary.usage,
+      conversationSummary,
     });
     await this.#client.sessions.addTraces({
       path: { session_id: sessionId },
@@ -174,6 +236,8 @@ export class HoneyHiveCursorInstrumentor {
     startTime: number;
     endTime: number;
     childrenIds: string[];
+    usage?: CursorDeltaSummary['usage'];
+    conversationSummary?: CursorConversationSummary;
   }): Promise<StartSessionResponse> {
     return this.#client.sessions.start({
       body: {
@@ -197,6 +261,7 @@ export class HoneyHiveCursorInstrumentor {
             project: this.#project,
             error: options.error,
             sdk: 'cursor',
+            conversation: options.conversationSummary,
           }),
           children_ids: options.childrenIds,
         },
@@ -204,4 +269,156 @@ export class HoneyHiveCursorInstrumentor {
     });
   }
 
+}
+
+function createDeltaSummary(): CursorDeltaSummary {
+  return {
+    counts: {},
+    stepDurationsMs: [],
+    thinkingDurationsMs: [],
+    shellOutputChunks: 0,
+    summaryUpdates: 0,
+  };
+}
+
+function createStreamSummary(): CursorStreamSummary {
+  return {
+    counts: {},
+    statuses: [],
+    taskUpdates: 0,
+    requests: 0,
+    toolCalls: {},
+  };
+}
+
+function recordStream(summary: CursorStreamSummary, event: SDKMessage): void {
+  summary.counts[event.type] = (summary.counts[event.type] ?? 0) + 1;
+
+  switch (event.type) {
+    case 'system':
+      summary.tools = event.tools;
+      break;
+    case 'tool_call': {
+      const toolStatuses = summary.toolCalls[event.name] ?? {};
+      toolStatuses[event.status] = (toolStatuses[event.status] ?? 0) + 1;
+      summary.toolCalls[event.name] = toolStatuses;
+      break;
+    }
+    case 'status':
+      summary.statuses.push(event.status);
+      break;
+    case 'task':
+      summary.taskUpdates += 1;
+      break;
+    case 'request':
+      summary.requests += 1;
+      break;
+    case 'user':
+    case 'assistant':
+    case 'thinking':
+      break;
+  }
+}
+
+function recordDelta(summary: CursorDeltaSummary, update: InteractionUpdate): void {
+  summary.counts[update.type] = (summary.counts[update.type] ?? 0) + 1;
+
+  switch (update.type) {
+    case 'text-delta':
+      summary.responseStartTime ??= Date.now();
+      break;
+    case 'turn-ended':
+      summary.usage = mergeUsage(summary.usage, update.usage);
+      break;
+    case 'token-delta':
+      summary.tokenDeltaTotal = (summary.tokenDeltaTotal ?? 0) + update.tokens;
+      break;
+    case 'step-completed':
+      summary.stepDurationsMs.push(update.stepDurationMs);
+      break;
+    case 'thinking-completed':
+      summary.thinkingDurationsMs.push(update.thinkingDurationMs);
+      break;
+    case 'shell-output-delta':
+      summary.shellOutputChunks += 1;
+      break;
+    case 'summary':
+    case 'summary-started':
+    case 'summary-completed':
+      summary.summaryUpdates += 1;
+      break;
+    case 'thinking-delta':
+    case 'tool-call-started':
+    case 'partial-tool-call':
+    case 'tool-call-completed':
+    case 'step-started':
+    case 'user-message-appended':
+      break;
+  }
+}
+
+function mergeUsage(
+  current: CursorDeltaSummary['usage'],
+  next: CursorDeltaSummary['usage'],
+): CursorDeltaSummary['usage'] {
+  if (!next) {
+    return current;
+  }
+  if (!current) {
+    return next;
+  }
+  return {
+    inputTokens: current.inputTokens + next.inputTokens,
+    outputTokens: current.outputTokens + next.outputTokens,
+    cacheReadTokens: current.cacheReadTokens + next.cacheReadTokens,
+    cacheWriteTokens: current.cacheWriteTokens + next.cacheWriteTokens,
+  };
+}
+
+function summarizeConversation(turns: ConversationTurn[]): CursorConversationSummary {
+  const summary: CursorConversationSummary = {
+    turns: turns.length,
+    agentTurns: 0,
+    shellTurns: 0,
+    stepCounts: {},
+    shellCommands: 0,
+    shellOutputs: 0,
+  };
+
+  for (const conversationTurn of turns) {
+    switch (conversationTurn.type) {
+      case 'agentConversationTurn':
+        summary.agentTurns += 1;
+        for (const step of conversationTurn.turn.steps) {
+          summary.stepCounts[step.type] = (summary.stepCounts[step.type] ?? 0) + 1;
+        }
+        break;
+      case 'shellConversationTurn':
+        summary.shellTurns += 1;
+        if (conversationTurn.turn.shellCommand) {
+          summary.shellCommands += 1;
+        }
+        if (conversationTurn.turn.shellOutput) {
+          summary.shellOutputs += 1;
+        }
+        break;
+    }
+  }
+
+  return summary;
+}
+
+function messageText(message: CursorMessageInput): string {
+  return typeof message === 'string' ? message : message.text;
+}
+
+function modelSelectionName(model?: ModelSelection): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+  if (!model.params?.length) {
+    return model.id;
+  }
+  const params = model.params.map((param) => `${param.id}=${param.value}`).join(',');
+  return `${model.id}(${params})`;
 }

--- a/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
+++ b/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
@@ -206,7 +206,6 @@ export class HoneyHiveCursorInstrumentor {
       startTime,
       endTime,
       childrenIds: [agentEventId],
-      usage: deltaSummary.usage,
       conversationSummary,
     });
     await this.#client.sessions.addTraces({
@@ -236,7 +235,6 @@ export class HoneyHiveCursorInstrumentor {
     startTime: number;
     endTime: number;
     childrenIds: string[];
-    usage?: CursorDeltaSummary['usage'];
     conversationSummary?: CursorConversationSummary;
   }): Promise<StartSessionResponse> {
     return this.#client.sessions.start({

--- a/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
+++ b/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
@@ -47,7 +47,7 @@ export class HoneyHiveCursorInstrumentor {
 
     try {
       const run = await options.agent.send(options.message, {
-        onStep: ({ step }) => {
+        onStep: async ({ step }) => {
           stepCounts[step.type] = (stepCounts[step.type] ?? 0) + 1;
 
           switch (step.type) {
@@ -76,6 +76,8 @@ export class HoneyHiveCursorInstrumentor {
               throw new Error(`Unhandled Cursor conversation step: ${JSON.stringify(exhaustive)}`);
             }
           }
+
+          await options.onStep?.(step);
         },
       });
       cursorRunId = run.id;

--- a/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
+++ b/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
@@ -327,6 +327,9 @@ function recordDelta(summary: CursorDeltaSummary, update: InteractionUpdate): vo
     case 'text-delta':
       summary.responseStartTime ??= Date.now();
       break;
+    case 'tool-call-started':
+      summary.responseStartTime = undefined;
+      break;
     case 'turn-ended':
       summary.usage = mergeUsage(summary.usage, update.usage);
       break;
@@ -348,7 +351,6 @@ function recordDelta(summary: CursorDeltaSummary, update: InteractionUpdate): vo
       summary.summaryUpdates += 1;
       break;
     case 'thinking-delta':
-    case 'tool-call-started':
     case 'partial-tool-call':
     case 'tool-call-completed':
     case 'step-started':

--- a/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
+++ b/cursor-sdk-honeyhive/instrumentor/HoneyHiveCursorInstrumentor.ts
@@ -1,0 +1,205 @@
+import crypto from 'node:crypto';
+
+import { type RunResultStatus } from '@cursor/sdk';
+import { Client, type StartSessionResponse } from '@honeyhive/api-client';
+
+import { createClientConfig } from './config.js';
+import { createAgentEvent, createFinalEvent, createToolEvent } from './events.js';
+import {
+  type CursorRunGit,
+  type HoneyHiveSanitizer,
+  type HoneyHiveCursorInstrumentorOptions,
+  type HoneyHiveTraceEvent,
+  type TraceCursorRunOptions,
+  type TraceCursorRunResult,
+} from './types.js';
+import { compactObject, defaultSanitize, formatError, isString } from './utils.js';
+
+export class HoneyHiveCursorInstrumentor {
+  #client: Client;
+  #project?: string;
+  #source: string;
+  #sanitize: HoneyHiveSanitizer;
+
+  constructor(options: HoneyHiveCursorInstrumentorOptions = {}) {
+    this.#client = new Client(createClientConfig(options));
+    this.#project = options.project;
+    this.#source = options.source ?? 'cursor-sdk-demo';
+    this.#sanitize = options.sanitize ?? defaultSanitize;
+  }
+
+  async traceRun(options: TraceCursorRunOptions): Promise<TraceCursorRunResult> {
+    const sessionId = crypto.randomUUID();
+    const agentEventId = crypto.randomUUID();
+    const finalEventId = crypto.randomUUID();
+    const startTime = Date.now();
+
+    let cursorRunId = '';
+    let status: RunResultStatus = 'error';
+    let resultText: string | undefined;
+    let durationMs: number | undefined;
+    let git: CursorRunGit | undefined;
+    let error: string | undefined;
+    let finalAssistantText = '';
+    let thinkingText = '';
+    const stepCounts: Record<string, number> = {};
+    const toolEvents: HoneyHiveTraceEvent[] = [];
+
+    try {
+      const run = await options.agent.send(options.message, {
+        onStep: ({ step }) => {
+          stepCounts[step.type] = (stepCounts[step.type] ?? 0) + 1;
+
+          switch (step.type) {
+            case 'thinkingMessage':
+              thinkingText += step.message.text;
+              break;
+            case 'assistantMessage':
+              finalAssistantText += step.message.text;
+              break;
+            case 'toolCall':
+              toolEvents.push(
+                createToolEvent({
+                  step,
+                  sessionId,
+                  parentId: agentEventId,
+                  project: this.#project,
+                  source: this.#source,
+                  thinkingText,
+                  sanitize: this.#sanitize,
+                }),
+              );
+              thinkingText = '';
+              break;
+            default: {
+              const exhaustive: never = step;
+              throw new Error(`Unhandled Cursor conversation step: ${JSON.stringify(exhaustive)}`);
+            }
+          }
+        },
+      });
+      cursorRunId = run.id;
+
+      const result = await run.wait();
+      status = result.status;
+      resultText = result.result;
+      durationMs = result.durationMs;
+      git = result.git;
+    } catch (caught) {
+      error = formatError(caught);
+      status = 'error';
+    }
+
+    const endTime = Date.now();
+    const result = resultText ?? finalAssistantText;
+    const exportedEvents = [
+      createAgentEvent({
+        eventId: agentEventId,
+        sessionId,
+        parentId: sessionId,
+        childrenIds: toolEvents.map((event) => event.event_id).filter(isString),
+        project: this.#project,
+        source: this.#source,
+        agentId: options.agent.agentId,
+        runId: cursorRunId,
+        model: options.model,
+        cwd: options.cwd,
+        prompt: options.message,
+        result,
+        status,
+        error,
+        startTime,
+        endTime,
+        durationMs,
+        git,
+        stepCounts,
+        thinkingText,
+        sanitize: this.#sanitize,
+      }),
+      ...toolEvents,
+      createFinalEvent({
+        eventId: finalEventId,
+        sessionId,
+        parentId: sessionId,
+        project: this.#project,
+        source: this.#source,
+        model: options.model,
+        prompt: options.message,
+        result,
+        status,
+        error,
+        endTime,
+        sanitize: this.#sanitize,
+      }),
+    ];
+
+    const session = await this.#startSession({
+      sessionId,
+      sessionName: options.sessionName ?? 'Cursor SDK HoneyHive Demo',
+      prompt: options.message,
+      cwd: options.cwd,
+      result,
+      status,
+      error,
+      startTime,
+      endTime,
+      childrenIds: [agentEventId, finalEventId],
+    });
+    await this.#client.sessions.addTraces({
+      path: { session_id: sessionId },
+      body: { logs: exportedEvents },
+    });
+
+    return {
+      cursorAgentId: options.agent.agentId,
+      cursorRunId,
+      cursorStatus: status,
+      honeyhiveSessionId: sessionId,
+      honeyhiveEventId: session.event_id,
+      exportedEvents: exportedEvents.length + 1,
+      toolEvents: toolEvents.length,
+    };
+  }
+
+  async #startSession(options: {
+    sessionId: string;
+    sessionName: string;
+    prompt: string;
+    cwd?: string;
+    result?: string;
+    status: RunResultStatus;
+    error?: string;
+    startTime: number;
+    endTime: number;
+    childrenIds: string[];
+  }): Promise<StartSessionResponse> {
+    return this.#client.sessions.start({
+      body: {
+        session: {
+          session_id: options.sessionId,
+          session_name: options.sessionName,
+          event_name: 'session.start',
+          source: this.#source,
+          start_time: options.startTime,
+          end_time: options.endTime,
+          duration: options.endTime - options.startTime,
+          inputs: compactObject({
+            prompt: options.prompt,
+            workspace: this.#sanitize(options.cwd, 'workspace'),
+          }),
+          outputs: compactObject({
+            status: options.status,
+            result: this.#sanitize(options.result, 'result'),
+          }),
+          metadata: compactObject({
+            project: this.#project,
+            error: options.error,
+            sdk: 'cursor',
+          }),
+          children_ids: options.childrenIds,
+        },
+      },
+    });
+  }
+
+}

--- a/cursor-sdk-honeyhive/instrumentor/config.ts
+++ b/cursor-sdk-honeyhive/instrumentor/config.ts
@@ -1,0 +1,10 @@
+import { type ClientConfig } from '@honeyhive/api-client';
+
+import { type HoneyHiveCursorInstrumentorOptions } from './types.js';
+
+export function createClientConfig(options: HoneyHiveCursorInstrumentorOptions): ClientConfig {
+  return {
+    apiKey: options.apiKey,
+    serverUrl: options.serverUrl ?? process.env.HH_API_URL,
+  };
+}

--- a/cursor-sdk-honeyhive/instrumentor/cursorSteps.ts
+++ b/cursor-sdk-honeyhive/instrumentor/cursorSteps.ts
@@ -1,0 +1,28 @@
+import {
+  type ToolConversationStep,
+} from './types.js';
+import { isRecord } from './utils.js';
+
+export function getToolArgs(tool: ToolConversationStep['message']): unknown {
+  return 'args' in tool ? tool.args : undefined;
+}
+
+export function getToolResult(tool: ToolConversationStep['message']): unknown {
+  return 'result' in tool ? tool.result : undefined;
+}
+
+export function getToolResultStatus(tool: ToolConversationStep['message']): string {
+  const result = getToolResult(tool);
+  if (isRecord(result) && typeof result.status === 'string') {
+    return result.status;
+  }
+  return result === undefined ? 'unknown' : 'completed';
+}
+
+export function getToolExecutionTimeMs(tool: ToolConversationStep['message']): number | undefined {
+  const result = getToolResult(tool);
+  if (!isRecord(result) || !isRecord(result.value)) {
+    return undefined;
+  }
+  return typeof result.value.executionTime === 'number' ? result.value.executionTime : undefined;
+}

--- a/cursor-sdk-honeyhive/instrumentor/events.ts
+++ b/cursor-sdk-honeyhive/instrumentor/events.ts
@@ -1,0 +1,176 @@
+import crypto from 'node:crypto';
+
+import { type RunResultStatus } from '@cursor/sdk';
+
+import {
+  getToolArgs,
+  getToolExecutionTimeMs,
+  getToolResult,
+  getToolResultStatus,
+} from './cursorSteps.js';
+import {
+  type CursorRunGit,
+  type HoneyHiveSanitizer,
+  type HoneyHiveTraceEvent,
+  type ToolConversationStep,
+} from './types.js';
+import { compact, compactObject, sanitizeRecord } from './utils.js';
+
+export function createToolEvent(options: {
+  step: ToolConversationStep;
+  sessionId: string;
+  parentId: string;
+  project?: string;
+  source: string;
+  thinkingText: string;
+  sanitize: HoneyHiveSanitizer;
+}): HoneyHiveTraceEvent {
+  const now = Date.now();
+  const tool = options.step.message;
+  const resultStatus = getToolResultStatus(tool);
+  const executionTime = getToolExecutionTimeMs(tool);
+  const result = getToolResult(tool);
+
+  return {
+    event_id: crypto.randomUUID(),
+    session_id: options.sessionId,
+    parent_id: options.parentId,
+    event_type: 'tool',
+    event_name: `tool.${tool.type}`,
+    source: options.source,
+    start_time: executionTime === undefined ? now : now - executionTime,
+    end_time: now,
+    duration: executionTime,
+    inputs: sanitizeRecord(
+      {
+        args: getToolArgs(tool),
+        thinking: options.thinkingText || undefined,
+      },
+      options.sanitize,
+      'toolArgs',
+    ),
+    outputs: sanitizeRecord({ result }, options.sanitize, 'toolResult'),
+    error: resultStatus === 'error' ? compact(result) : undefined,
+    metadata: compactObject({
+      project: options.project,
+      'gen_ai.system': 'cursor',
+      'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.tool.name': tool.type,
+      'cursor.tool.status': resultStatus,
+    }),
+  };
+}
+
+export function createAgentEvent(options: {
+  eventId: string;
+  sessionId: string;
+  parentId: string;
+  childrenIds: string[];
+  project?: string;
+  source: string;
+  agentId: string;
+  runId: string;
+  model?: string;
+  cwd?: string;
+  prompt: string;
+  result?: string;
+  status: RunResultStatus;
+  error?: string;
+  startTime: number;
+  endTime: number;
+  durationMs?: number;
+  git?: CursorRunGit;
+  stepCounts: Record<string, number>;
+  thinkingText: string;
+  sanitize: HoneyHiveSanitizer;
+}): HoneyHiveTraceEvent {
+  return {
+    event_id: options.eventId,
+    session_id: options.sessionId,
+    parent_id: options.parentId,
+    children_ids: options.childrenIds,
+    event_type: 'chain',
+    event_name: 'agent.run',
+    source: options.source,
+    start_time: options.startTime,
+    end_time: options.endTime,
+    duration: options.durationMs ?? options.endTime - options.startTime,
+    config: compactObject({
+      model: options.model,
+      'gen_ai.system': 'cursor',
+      'gen_ai.operation.name': 'invoke_agent',
+      'gen_ai.agent.name': 'Cursor SDK Agent',
+    }),
+    inputs: compactObject({
+      prompt: options.prompt,
+      workspace: options.sanitize(options.cwd, 'workspace'),
+    }),
+    outputs: compactObject({
+      status: options.status,
+      result: options.sanitize(options.result, 'result'),
+      thinking: options.sanitize(options.thinkingText, 'thinking'),
+    }),
+    error: eventError(options.status, options.error),
+    metadata: compactObject({
+      project: options.project,
+      'cursor.agent_id': options.agentId,
+      'cursor.run_id': options.runId,
+      'cursor.runtime': 'local',
+      'cursor.git': options.sanitize(options.git, 'metadata'),
+      'cursor.step_counts': options.stepCounts,
+    }),
+  };
+}
+
+export function createFinalEvent(options: {
+  eventId: string;
+  sessionId: string;
+  parentId: string;
+  project?: string;
+  source: string;
+  model?: string;
+  prompt: string;
+  result?: string;
+  status: RunResultStatus;
+  error?: string;
+  endTime: number;
+  sanitize: HoneyHiveSanitizer;
+}): HoneyHiveTraceEvent {
+  return {
+    event_id: options.eventId,
+    session_id: options.sessionId,
+    parent_id: options.parentId,
+    event_type: 'model',
+    event_name: 'turn.agent',
+    source: options.source,
+    start_time: options.endTime,
+    end_time: options.endTime,
+    duration: 0,
+    config: compactObject({
+      model: options.model,
+      'gen_ai.system': 'cursor',
+      'gen_ai.operation.name': 'chat',
+    }),
+    inputs: {
+      prompt: options.sanitize(options.prompt, 'prompt'),
+    },
+    outputs: compactObject({
+      status: options.status,
+      response: options.sanitize(options.result, 'result'),
+    }),
+    error: eventError(options.status, options.error),
+    metadata: compactObject({
+      project: options.project,
+    }),
+  };
+}
+
+function eventError(cursorStatus: RunResultStatus, error?: string): string | undefined {
+  if (error) {
+    return error;
+  }
+  if (cursorStatus === 'finished') {
+    return undefined;
+  }
+  return `Cursor run ${cursorStatus}`;
+}

--- a/cursor-sdk-honeyhive/instrumentor/events.ts
+++ b/cursor-sdk-honeyhive/instrumentor/events.ts
@@ -110,11 +110,6 @@ export function createAgentEvent(options: {
       'gen_ai.operation.name': 'invoke_agent',
       'gen_ai.agent.name': 'Cursor SDK Agent',
     }),
-    metrics: compactObject({
-      token_delta_total: options.deltaSummary.tokenDeltaTotal,
-      step_duration_ms_total: sum(options.deltaSummary.stepDurationsMs),
-      thinking_duration_ms_total: sum(options.deltaSummary.thinkingDurationsMs),
-    }),
     inputs: compactObject({
       prompt: options.prompt,
       workspace: options.sanitize(options.cwd, 'workspace'),
@@ -135,6 +130,9 @@ export function createAgentEvent(options: {
       'cursor.delta_counts': options.deltaSummary.counts,
       'cursor.stream': options.streamSummary,
       'cursor.stream_error': options.streamError,
+      'cursor.token_delta_total': options.deltaSummary.tokenDeltaTotal,
+      'cursor.step_duration_ms_total': sum(options.deltaSummary.stepDurationsMs),
+      'cursor.thinking_duration_ms_total': sum(options.deltaSummary.thinkingDurationsMs),
       'cursor.step_durations_ms': options.deltaSummary.stepDurationsMs.length
         ? options.deltaSummary.stepDurationsMs
         : undefined,

--- a/cursor-sdk-honeyhive/instrumentor/events.ts
+++ b/cursor-sdk-honeyhive/instrumentor/events.ts
@@ -9,7 +9,11 @@ import {
   getToolResultStatus,
 } from './cursorSteps.js';
 import {
+  type CursorConversationSummary,
+  type CursorDeltaSummary,
   type CursorRunGit,
+  type CursorStreamSummary,
+  type CursorTokenUsage,
   type HoneyHiveSanitizer,
   type HoneyHiveTraceEvent,
   type ToolConversationStep,
@@ -81,6 +85,11 @@ export function createAgentEvent(options: {
   durationMs?: number;
   git?: CursorRunGit;
   stepCounts: Record<string, number>;
+  deltaSummary: CursorDeltaSummary;
+  streamSummary: CursorStreamSummary;
+  streamError?: string;
+  conversationSummary?: CursorConversationSummary;
+  conversationError?: string;
   thinkingText: string;
   sanitize: HoneyHiveSanitizer;
 }): HoneyHiveTraceEvent {
@@ -101,6 +110,11 @@ export function createAgentEvent(options: {
       'gen_ai.operation.name': 'invoke_agent',
       'gen_ai.agent.name': 'Cursor SDK Agent',
     }),
+    metrics: compactObject({
+      token_delta_total: options.deltaSummary.tokenDeltaTotal,
+      step_duration_ms_total: sum(options.deltaSummary.stepDurationsMs),
+      thinking_duration_ms_total: sum(options.deltaSummary.thinkingDurationsMs),
+    }),
     inputs: compactObject({
       prompt: options.prompt,
       workspace: options.sanitize(options.cwd, 'workspace'),
@@ -118,6 +132,19 @@ export function createAgentEvent(options: {
       'cursor.runtime': 'local',
       'cursor.git': options.sanitize(options.git, 'metadata'),
       'cursor.step_counts': options.stepCounts,
+      'cursor.delta_counts': options.deltaSummary.counts,
+      'cursor.stream': options.streamSummary,
+      'cursor.stream_error': options.streamError,
+      'cursor.step_durations_ms': options.deltaSummary.stepDurationsMs.length
+        ? options.deltaSummary.stepDurationsMs
+        : undefined,
+      'cursor.thinking_durations_ms': options.deltaSummary.thinkingDurationsMs.length
+        ? options.deltaSummary.thinkingDurationsMs
+        : undefined,
+      'cursor.shell_output_chunks': options.deltaSummary.shellOutputChunks || undefined,
+      'cursor.summary_updates': options.deltaSummary.summaryUpdates || undefined,
+      'cursor.conversation': options.conversationSummary,
+      'cursor.conversation_error': options.conversationError,
     }),
   };
 }
@@ -133,9 +160,14 @@ export function createFinalEvent(options: {
   result?: string;
   status: RunResultStatus;
   error?: string;
+  startTime: number;
   endTime: number;
+  usage?: CursorTokenUsage;
   sanitize: HoneyHiveSanitizer;
 }): HoneyHiveTraceEvent {
+  const usageFields = tokenUsageFields(options.usage);
+  const startTime = options.startTime;
+
   return {
     event_id: options.eventId,
     session_id: options.sessionId,
@@ -143,24 +175,28 @@ export function createFinalEvent(options: {
     event_type: 'model',
     event_name: 'turn.agent',
     source: options.source,
-    start_time: options.endTime,
+    start_time: startTime,
     end_time: options.endTime,
-    duration: 0,
+    duration: options.endTime - startTime,
     config: compactObject({
       model: options.model,
+      provider: 'cursor',
       'gen_ai.system': 'cursor',
       'gen_ai.operation.name': 'chat',
     }),
-    inputs: {
-      prompt: options.sanitize(options.prompt, 'prompt'),
-    },
+    inputs: compactObject({
+      chat_history: [{ role: 'user', content: options.sanitize(options.prompt, 'prompt') }],
+    }),
     outputs: compactObject({
+      role: 'assistant',
+      content: options.sanitize(options.result, 'result'),
       status: options.status,
-      response: options.sanitize(options.result, 'result'),
     }),
     error: eventError(options.status, options.error),
     metadata: compactObject({
       project: options.project,
+      provider: 'cursor',
+      ...usageFields,
     }),
   };
 }
@@ -173,4 +209,25 @@ function eventError(cursorStatus: RunResultStatus, error?: string): string | und
     return undefined;
   }
   return `Cursor run ${cursorStatus}`;
+}
+
+function tokenUsageFields(usage?: CursorTokenUsage): Record<string, number> {
+  if (!usage) {
+    return {};
+  }
+
+  return {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+    cache_read_input_tokens: usage.cacheReadTokens,
+    cache_write_input_tokens: usage.cacheWriteTokens,
+  };
+}
+
+function sum(values: number[]): number | undefined {
+  if (!values.length) {
+    return undefined;
+  }
+  return values.reduce((total, value) => total + value, 0);
 }

--- a/cursor-sdk-honeyhive/instrumentor/index.ts
+++ b/cursor-sdk-honeyhive/instrumentor/index.ts
@@ -1,0 +1,6 @@
+export { HoneyHiveCursorInstrumentor } from './HoneyHiveCursorInstrumentor.js';
+export type {
+  HoneyHiveCursorInstrumentorOptions,
+  TraceCursorRunOptions,
+  TraceCursorRunResult,
+} from './types.js';

--- a/cursor-sdk-honeyhive/instrumentor/types.ts
+++ b/cursor-sdk-honeyhive/instrumentor/types.ts
@@ -1,4 +1,13 @@
-import { type ConversationStep, type RunResult, type RunResultStatus, type SDKAgent } from '@cursor/sdk';
+import {
+  type ConversationStep,
+  type InteractionUpdate,
+  type RunResult,
+  type RunResultStatus,
+  type SDKAgent,
+  type SDKMessage,
+  type SDKUserMessage,
+  type SendOptions,
+} from '@cursor/sdk';
 import { type AddSessionTracesRequest } from '@honeyhive/api-client';
 
 export type HoneyHiveTraceEvent = AddSessionTracesRequest['logs'][number];
@@ -14,6 +23,43 @@ export type SanitizeContext =
 
 export type HoneyHiveSanitizer = (value: unknown, context: SanitizeContext) => unknown;
 export type ToolConversationStep = Extract<ConversationStep, { type: 'toolCall' }>;
+export type CursorMessageInput = string | SDKUserMessage;
+
+export interface CursorTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface CursorDeltaSummary {
+  counts: Record<string, number>;
+  usage?: CursorTokenUsage;
+  tokenDeltaTotal?: number;
+  responseStartTime?: number;
+  stepDurationsMs: number[];
+  thinkingDurationsMs: number[];
+  shellOutputChunks: number;
+  summaryUpdates: number;
+}
+
+export interface CursorConversationSummary {
+  turns: number;
+  agentTurns: number;
+  shellTurns: number;
+  stepCounts: Record<string, number>;
+  shellCommands: number;
+  shellOutputs: number;
+}
+
+export interface CursorStreamSummary {
+  counts: Record<string, number>;
+  statuses: string[];
+  taskUpdates: number;
+  requests: number;
+  toolCalls: Record<string, Record<string, number>>;
+  tools?: string[];
+}
 
 export interface HoneyHiveCursorInstrumentorOptions {
   apiKey?: string;
@@ -25,11 +71,14 @@ export interface HoneyHiveCursorInstrumentorOptions {
 
 export interface TraceCursorRunOptions {
   agent: SDKAgent;
-  message: string;
+  message: CursorMessageInput;
   sessionName?: string;
   model?: string;
   cwd?: string;
+  sendOptions?: Omit<SendOptions, 'onDelta' | 'onStep'>;
   onStep?: (step: ConversationStep) => void | Promise<void>;
+  onDelta?: (update: InteractionUpdate) => void | Promise<void>;
+  onStream?: (event: SDKMessage) => void | Promise<void>;
 }
 
 export interface TraceCursorRunResult {

--- a/cursor-sdk-honeyhive/instrumentor/types.ts
+++ b/cursor-sdk-honeyhive/instrumentor/types.ts
@@ -1,0 +1,42 @@
+import { type ConversationStep, type RunResult, type RunResultStatus, type SDKAgent } from '@cursor/sdk';
+import { type AddSessionTracesRequest } from '@honeyhive/api-client';
+
+export type HoneyHiveTraceEvent = AddSessionTracesRequest['logs'][number];
+export type CursorRunGit = RunResult['git'];
+export type SanitizeContext =
+  | 'prompt'
+  | 'result'
+  | 'thinking'
+  | 'toolArgs'
+  | 'toolResult'
+  | 'metadata'
+  | 'workspace';
+
+export type HoneyHiveSanitizer = (value: unknown, context: SanitizeContext) => unknown;
+export type ToolConversationStep = Extract<ConversationStep, { type: 'toolCall' }>;
+
+export interface HoneyHiveCursorInstrumentorOptions {
+  apiKey?: string;
+  project?: string;
+  source?: string;
+  serverUrl?: string;
+  sanitize?: HoneyHiveSanitizer;
+}
+
+export interface TraceCursorRunOptions {
+  agent: SDKAgent;
+  message: string;
+  sessionName?: string;
+  model?: string;
+  cwd?: string;
+}
+
+export interface TraceCursorRunResult {
+  cursorAgentId: string;
+  cursorRunId: string;
+  cursorStatus: RunResultStatus;
+  honeyhiveSessionId: string;
+  honeyhiveEventId: string;
+  exportedEvents: number;
+  toolEvents: number;
+}

--- a/cursor-sdk-honeyhive/instrumentor/types.ts
+++ b/cursor-sdk-honeyhive/instrumentor/types.ts
@@ -29,6 +29,7 @@ export interface TraceCursorRunOptions {
   sessionName?: string;
   model?: string;
   cwd?: string;
+  onStep?: (step: ConversationStep) => void | Promise<void>;
 }
 
 export interface TraceCursorRunResult {

--- a/cursor-sdk-honeyhive/instrumentor/utils.ts
+++ b/cursor-sdk-honeyhive/instrumentor/utils.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { type HoneyHiveSanitizer, type SanitizeContext } from './types.js';
 
 const SENSITIVE_KEY_PATTERN = /api[_-]?key|authorization|cookie|credential|password|secret|token/i;
+const PATH_KEY_PATTERN = /(^|[_-])(cwd|dir|directory|file|path)$|(?:Cwd|Dir|Directory|File|Path)$/;
 const REDACTED = '[redacted]';
 
 export function compact(value: unknown, maxLength = 8000): string {
@@ -51,8 +52,11 @@ export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
-function sanitizeValue(value: unknown, depth = 0): unknown {
+function sanitizeValue(value: unknown, depth = 0, key?: string): unknown {
   if (typeof value === 'string') {
+    if (key && PATH_KEY_PATTERN.test(key) && path.isAbsolute(value)) {
+      return path.basename(value);
+    }
     return truncateString(value);
   }
   if (typeof value !== 'object' || value === null) {
@@ -68,7 +72,7 @@ function sanitizeValue(value: unknown, depth = 0): unknown {
   return Object.fromEntries(
     Object.entries(value).slice(0, 100).map(([key, entryValue]) => [
       key,
-      SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : sanitizeValue(entryValue, depth + 1),
+      SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : sanitizeValue(entryValue, depth + 1, key),
     ]),
   );
 }

--- a/cursor-sdk-honeyhive/instrumentor/utils.ts
+++ b/cursor-sdk-honeyhive/instrumentor/utils.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+
+import { type HoneyHiveSanitizer, type SanitizeContext } from './types.js';
+
+const SENSITIVE_KEY_PATTERN = /api[_-]?key|authorization|cookie|credential|password|secret|token/i;
+const REDACTED = '[redacted]';
+
+export function compact(value: unknown, maxLength = 8000): string {
+  if (value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.length > maxLength ? `${value.slice(0, maxLength)}... [truncated]` : value;
+  }
+
+  const serialized = JSON.stringify(value) ?? '';
+  return serialized.length > maxLength ? `${serialized.slice(0, maxLength)}... [truncated]` : serialized;
+}
+
+export function compactObject(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+}
+
+export function defaultSanitize(value: unknown, context: SanitizeContext): unknown {
+  if (context === 'workspace' && typeof value === 'string') {
+    return path.basename(value);
+  }
+  return sanitizeValue(value);
+}
+
+export function sanitizeRecord(
+  values: Record<string, unknown>,
+  sanitize: HoneyHiveSanitizer,
+  context: SanitizeContext,
+): Record<string, unknown> {
+  return compactObject(Object.fromEntries(Object.entries(values).map(([key, value]) => [key, sanitize(value, context)])));
+}
+
+export function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') {
+    return truncateString(value);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  if (depth >= 6) {
+    return '[truncated-depth]';
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 50).map((item) => sanitizeValue(item, depth + 1));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).slice(0, 100).map(([key, entryValue]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : sanitizeValue(entryValue, depth + 1),
+    ]),
+  );
+}
+
+function truncateString(value: string, maxLength = 4000): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}... [truncated]` : value;
+}

--- a/cursor-sdk-honeyhive/package.json
+++ b/cursor-sdk-honeyhive/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "cursor-sdk-honeyhive",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Trace a Cursor SDK agent run with HoneyHive",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "start": "tsx index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.9",
+    "@honeyhive/api-client": "2.0.0-rc3",
+    "dotenv": "^17.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.8",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sqlite3"
+    ]
+  }
+}

--- a/cursor-sdk-honeyhive/pnpm-lock.yaml
+++ b/cursor-sdk-honeyhive/pnpm-lock.yaml
@@ -1,0 +1,1710 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@cursor/sdk':
+        specifier: ^1.0.9
+        version: 1.0.9
+      '@honeyhive/api-client':
+        specifier: 2.0.0-rc3
+        version: 2.0.0-rc3
+      dotenv:
+        specifier: ^17.0.0
+        version: 17.4.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.8
+        version: 22.19.17
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.9':
+    resolution: {integrity: sha512-C9O4WGRt4u0f/qFXgYYdrfEi2zui53Ax21JrdvliQd9mzKje+fjxwGWy37SHxqE4hSMR7G/+L7rqf0dyIdtUBQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cursor/sdk-darwin-x64@1.0.9':
+    resolution: {integrity: sha512-ct81x1xEyx5tL+tJHpxdwDE0qpMJtey6VHyLxUHjrCMeJTZvFhmAwu6jcv88KgXsimXkBAwQ9E4n0O6gS9ND9Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cursor/sdk-linux-arm64@1.0.9':
+    resolution: {integrity: sha512-EO8rQaEItCzNnR5OKQms364Tuz6CwceP2CAZH7RKgoai+detIQfkNjxqBnChhKA1Sq+8QERCZkrdNEFD+Slk4g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cursor/sdk-linux-x64@1.0.9':
+    resolution: {integrity: sha512-hTtRyZBKz3WMM7xmuDSvlIhYkOUQCgG+JsCKerY3RDeOW2Fqwh5Vj8qpBKS13+T1NNNRFA4kLnPnh9WxqI9vLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cursor/sdk-win32-x64@1.0.9':
+    resolution: {integrity: sha512-XM4nQUNgwsykAhd8Dil9PKACfiGJPXTZXmsjrkIyBtnjTFqNRPsPHpHoq++a3RQ6ZAvcgje03SgNSLE39WE6uA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@cursor/sdk@1.0.9':
+    resolution: {integrity: sha512-UYoWWnVqmS5mA6nteR8iyxRQrscSvqZUFYyaboQkCWNvETLTm2JI7tTx/RhCprEToukqufhF2pINOBJmPeFfdA==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@honeyhive/api-client@2.0.0-rc3':
+    resolution: {integrity: sha512-C869LedSsSe7sJFtzJWnrqN3nkwLJnpeGegBWybcc+mbxEbVhDMHi44ssW8Zi4SYjD/cyogHOu33nRBVC1ZqKA==}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
+
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
+
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
+    engines: {node: '>= 12'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.8:
+    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@bufbuild/protobuf@1.10.0': {}
+
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 5.29.0
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.9':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.9':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.9':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.9':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.9':
+    optional: true
+
+  '@cursor/sdk@1.0.9':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      sqlite3: 5.1.7
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.9
+      '@cursor/sdk-darwin-x64': 1.0.9
+      '@cursor/sdk-linux-arm64': 1.0.9
+      '@cursor/sdk-linux-x64': 1.0.9
+      '@cursor/sdk-win32-x64': 1.0.9
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@gar/promisify@1.1.3':
+    optional: true
+
+  '@honeyhive/api-client@2.0.0-rc3':
+    dependencies:
+      axios: 1.15.0
+      openapi-fetch: 0.17.0
+    transitivePeerDependencies:
+      - debug
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
+
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
+
+  '@tootallnate/once@1.1.2':
+    optional: true
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  abbrev@1.1.1:
+    optional: true
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+    optional: true
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
+
+  ansi-regex@5.0.1:
+    optional: true
+
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
+
+  asynckit@0.4.0: {}
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  balanced-match@1.0.2:
+    optional: true
+
+  base64-js@1.5.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
+  clean-stack@2.2.0:
+    optional: true
+
+  color-support@1.1.3:
+    optional: true
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  concat-map@0.0.1:
+    optional: true
+
+  console-control-strings@1.1.0:
+    optional: true
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+    optional: true
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
+
+  detect-libc@2.1.2: {}
+
+  dotenv@17.4.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  emoji-regex@8.0.0:
+    optional: true
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@2.2.1:
+    optional: true
+
+  err-code@2.0.3:
+    optional: true
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  expand-template@2.0.3: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  fs-constants@1.0.0: {}
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11:
+    optional: true
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  has-unicode@2.0.1:
+    optional: true
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-cache-semantics@4.2.0:
+    optional: true
+
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+    optional: true
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
+  ieee754@1.2.1: {}
+
+  imurmurhash@0.1.4:
+    optional: true
+
+  indent-string@4.0.0:
+    optional: true
+
+  infer-owner@1.0.4:
+    optional: true
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  ip-address@10.1.1:
+    optional: true
+
+  is-fullwidth-code-point@3.0.0:
+    optional: true
+
+  is-lambda@1.0.1:
+    optional: true
+
+  isexe@2.0.0:
+    optional: true
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-response@3.1.0: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
+  minimist@1.2.8: {}
+
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
+
+  ms@2.1.3:
+    optional: true
+
+  napi-build-utils@2.0.0: {}
+
+  negotiator@0.6.4:
+    optional: true
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
+
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
+
+  path-is-absolute@1.0.1:
+    optional: true
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  promise-inflight@1.0.1:
+    optional: true
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
+
+  proxy-from-env@2.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  retry@0.12.0:
+    optional: true
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+    optional: true
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2:
+    optional: true
+
+  semver@7.7.4: {}
+
+  set-blocking@2.0.0:
+    optional: true
+
+  signal-exit@3.0.7:
+    optional: true
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.8
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.8:
+    dependencies:
+      ip-address: 10.1.1
+      smart-buffer: 4.2.0
+    optional: true
+
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    optional: true
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    optional: true
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
+
+  util-deprecate@1.0.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+    optional: true
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
+  wrappy@1.0.2: {}
+
+  yallist@4.0.0: {}
+
+  zod@3.25.76: {}

--- a/cursor-sdk-honeyhive/tsconfig.build.json
+++ b/cursor-sdk-honeyhive/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "noEmit": false,
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["instrumentor/**/*.ts"]
+}

--- a/cursor-sdk-honeyhive/tsconfig.json
+++ b/cursor-sdk-honeyhive/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "instrumentor/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds a Cursor SDK TypeScript cookbook that exports local agent runs into HoneyHive with `@cursor/sdk` and `@honeyhive/api-client`.
- Ships a reusable `instrumentor/` module that maps stable Cursor SDK surfaces (`onDelta`, `onStep`, `run.stream()`, `run.wait()`, and `run.conversation()`) into a HoneyHive session, agent chain, tool events, and final assistant model turn.
- Documents setup, environment variables, trace shape, customization hooks, local validation, and the public-beta status of Cursor's TypeScript SDK.

## Trace shape
- `session.start` is the root container for the Cursor run.
- `agent.run` captures the whole SDK invocation, Cursor IDs, stream/delta summaries, step timing, conversation summary, status, and result.
- `tool.<name>` events capture Cursor tool args/results with secret/path sanitization.
- `turn.agent` captures the final assistant response as a model event with chat-shaped inputs/outputs and token metadata from Cursor's `turn-ended` delta.

## Validation
- `pnpm typecheck` in `cursor-sdk-honeyhive`
- `pnpm build` in `cursor-sdk-honeyhive`
- `pnpm start` with local API keys; verified a 4-event HoneyHive trace containing session, agent, tool, and final model events.
- Longer read-only run with README, package, and instrumentor file inspection; verified a 13-event HoneyHive trace with 10 tool events, correct hierarchy, path-like tool args sanitized, stream/delta counts stored as metadata, model token metadata, and the final assistant turn timestamped after tool execution.