### PR TITLE
HHAI-4971: Phase A — synth verification + deploy playbook (Phase B blocked on sandbox profile)

### DIFF
--- a/strands-bedrock-lambda-cdk-cookbook/README.md
+++ b/strands-bedrock-lambda-cdk-cookbook/README.md
@@ -17,3 +17,7 @@ npx --yes cdk synth
 ```
 
 `cdk synth` emits CloudFormation to `cdk.out/`. The stack currently synthesizes empty; resources land in follow-up PRs.
+
+## Version pins
+
+`lambda/requirements.txt` uses exact pins — reproducibility over flexibility. The HoneyHive SDK is pinned to `1.0.0rc21` because it's the earliest rc with both the session_id baggage isolation (prevents warm-Lambda session bleed across users) and the event_type priority detection that routes Strands GenAI ops (`invoke_agent` → chain, `execute_tool` → tool, `chat` → model) instead of falling through to the generic `tool` default. See the header of `lambda/requirements.txt` for the full rationale.

--- a/strands-bedrock-lambda-cdk-cookbook/docs/deploy-playbook.md
+++ b/strands-bedrock-lambda-cdk-cookbook/docs/deploy-playbook.md
@@ -1,0 +1,276 @@
+# Deploy playbook
+
+End-to-end runbook for taking the `strands-bedrock-lambda-cdk-cookbook` stack from a clean checkout to a live API URL, three verified HoneyHive traces, and a clean teardown. This is the script the NW accelerator demo (and HHAI-4973 dry run) follows.
+
+The README covers the user-facing flow. This playbook adds the ops-side detail: profile pre-checks, expected outputs at each step, fallback screenshot checklist, and rollback paths. Read this before running the demo live.
+
+## Prerequisites
+
+- **AWS profile for a HoneyHive-owned sandbox account.** Do *not* point this at a customer account (never at NW's), and do not reuse a control-plane / production HoneyHive profile. If you are unsure which profile on the demo machine is the sandbox, ask in #hackathon-accelerator before proceeding — wrong account = accidental provisioning.
+- **Region: `us-east-1`.** This matches Nationwide's region and maximizes Bedrock model availability. If you must use a different region, swap it everywhere below (bootstrap, Secrets Manager, inference profile ARN, list-inference-profiles).
+- **Python 3.12** available as `python3.12` on `$PATH`. Lambda runtime is pinned to 3.12 — mismatched local Python will produce native-wheel surprises during Docker bundling.
+- **Node.js 18+** for the CDK CLI (`npx --yes cdk ...`).
+- **Docker Desktop running.** `cdk deploy` uses the official `public.ecr.aws/sam/build-python3.12` image to bundle Lambda dependencies. If Docker is not up, synth/deploy fails with `docker exited with status 125`.
+- **HoneyHive project + API key.** Project name must match `HONEYHIVE_PROJECT` at deploy time; a typo produces a silent trace drop.
+- **Bedrock model access.** In the Bedrock console → *Model access*, grant access to the model family you intend to use (Claude 4.5 Sonnet for this demo). Access grants are region-scoped.
+
+## Quick pre-flight
+
+Before doing anything destructive, confirm you're pointed at the right account:
+
+```bash
+export AWS_PROFILE=<SANDBOX_PROFILE>
+aws sts get-caller-identity
+# Expect: Account = HoneyHive sandbox account ID. Arn contains the sandbox role name.
+aws configure get region
+# Expect: us-east-1
+```
+
+If the account ID doesn't match the known sandbox, stop. Do not proceed.
+
+## Step-by-step
+
+All commands run from `cookbook/strands-bedrock-lambda-cdk-cookbook/` unless otherwise noted.
+
+### 1. Clone & enter
+
+```bash
+git clone https://github.com/honeyhiveai/cookbook.git
+cd cookbook/strands-bedrock-lambda-cdk-cookbook
+```
+
+For this sub-issue, use the stacked branch:
+
+```bash
+git checkout hhai-4971-deploy-test
+```
+
+### 2. Install CDK synth deps
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Sanity check:
+
+```bash
+pip list | grep -E "aws-cdk-lib|constructs|boto3"
+# Expect: aws-cdk-lib 2.248+ , constructs 10.5+ , boto3 1.34+
+```
+
+### 3. Ensure Docker is up
+
+```bash
+docker info | grep "Server Version"
+# Expect: a version line, no "Cannot connect" errors.
+```
+
+If Docker is not running: `open -a Docker`, wait ~30s, retry.
+
+### 4. Set AWS profile + region
+
+```bash
+export AWS_PROFILE=<SANDBOX_PROFILE>
+export AWS_REGION=us-east-1
+aws sts get-caller-identity   # confirm account
+```
+
+### 5. Create the HoneyHive API key secret
+
+The stack reads via CloudFormation dynamic reference — the plaintext key never lands in the synthesized template.
+
+```bash
+export HONEYHIVE_API_KEY="hh-..."
+aws secretsmanager create-secret \
+  --name honeyhive/api-key \
+  --secret-string "$HONEYHIVE_API_KEY" \
+  --region us-east-1
+```
+
+If the secret already exists:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id honeyhive/api-key \
+  --secret-string "$HONEYHIVE_API_KEY" \
+  --region us-east-1
+```
+
+### 6. Pick a model ARN
+
+For Claude 4.5 Sonnet and any chargeback-tagged workload, use an **application-inference-profile** ARN. List profiles in the sandbox:
+
+```bash
+aws bedrock list-inference-profiles --region us-east-1 \
+  --query 'inferenceProfileSummaries[].{name:inferenceProfileName, arn:inferenceProfileArn, type:type}' \
+  --output table
+```
+
+Export the one you want:
+
+```bash
+export MODEL_ARN="arn:aws:bedrock:us-east-1:<ACCOUNT_ID>:application-inference-profile/<PROFILE_ID>"
+```
+
+If no application inference profile exists yet, create one in the Bedrock console (*Inference profiles* → *Create application inference profile*) against a Claude 4.5 Sonnet system-defined profile. Tag it `hackathon=accelerator` for chargeback visibility.
+
+### 7. Bootstrap CDK (first time per account/region)
+
+```bash
+npx --yes cdk bootstrap aws://<ACCOUNT_ID>/us-east-1
+```
+
+Successful output ends with `✅  Environment aws://<ACCOUNT_ID>/us-east-1 bootstrapped`. Re-running is a no-op.
+
+### 8. Synth (optional sanity check)
+
+```bash
+npx --yes cdk synth --quiet \
+  -c honeyhive_project=<YOUR_PROJECT> \
+  -c model_arn="$MODEL_ARN"
+```
+
+Synth requires Docker (it runs the Lambda bundling step). If it completes without error, the template is valid.
+
+### 9. Diff against the deployed stack
+
+```bash
+npx --yes cdk diff \
+  -c honeyhive_project=<YOUR_PROJECT> \
+  -c model_arn="$MODEL_ARN"
+```
+
+On a clean account this shows only additions: Lambda function, IAM role + inline policy, HTTP API + route + integration, LogGroup, Secrets Manager reference. Review the IAM policy statements before proceeding — specifically the `bedrock:Invoke*` resource list should include `application-inference-profile/*`.
+
+### 10. Deploy
+
+```bash
+npx --yes cdk deploy \
+  -c honeyhive_project=<YOUR_PROJECT> \
+  -c model_arn="$MODEL_ARN"
+```
+
+Expected duration: 2–4 minutes. CDK prints three outputs when done:
+
+```
+StrandsBedrockLambdaStack.ApiUrl = https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com
+StrandsBedrockLambdaStack.LambdaArn = arn:aws:lambda:us-east-1:...:function:...
+StrandsBedrockLambdaStack.RoleArn = arn:aws:iam::...:role/...
+```
+
+Capture the full terminal output for `fallback/01-cdk-deploy-output.png`.
+
+```bash
+export API_URL="<ApiUrl output>"
+```
+
+### 11. Invoke 3× back-to-back
+
+```bash
+for i in 1 2 3; do
+  echo "--- invocation $i ---"
+  curl -sS -X POST "$API_URL/invoke" \
+    -H 'content-type: application/json' \
+    -d "{\"prompt\": \"invocation $i: what is $((i*17)) * $((i*23))?\"}"
+  echo
+done
+```
+
+Each response has `response`, `session_url`, and `session_id`. Capture this output for `fallback/02-curl-response.png`.
+
+### 12. Verify in HoneyHive Studio
+
+- Open `session_url` from any one response, OR go to `app.honeyhive.ai/<project>/sessions` and filter "last 5 min".
+- Confirm 3 distinct session_ids (no duplicates = baggage isolation working).
+- Open one session. Expand spans. Expected hierarchy:
+  - Top-level session span (`lambda-<hex>`)
+  - `invoke_agent` → shows as **chain**
+  - `chat` → shows as **model** (Bedrock Converse call, with prompt/completion + token counts)
+  - `execute_tool` → shows as **tool** (the `calculator` span)
+- Latency target: trace visible in Studio within 15s of the curl completing.
+
+Capture:
+- `fallback/03-studio-session-list.png` — filtered session list showing 3 distinct sessions.
+- `fallback/04-studio-trace-spans.png` — one session expanded with agent/model/tool spans visible.
+
+### 13. Teardown
+
+```bash
+npx --yes cdk destroy
+# Type "y" to confirm.
+```
+
+Capture clean destroy output for `fallback/05-cdk-destroy.png`.
+
+Optionally clean up the HoneyHive secret:
+
+```bash
+aws secretsmanager delete-secret \
+  --secret-id honeyhive/api-key \
+  --force-delete-without-recovery \
+  --region us-east-1
+```
+
+## Verification checklist
+
+- [ ] `cdk deploy` exits 0 with 3 outputs printed (ApiUrl, LambdaArn, RoleArn)
+- [ ] `curl $API_URL/invoke` returns HTTP 200 with JSON containing `response`, `session_url`, `session_id`
+- [ ] 3 back-to-back curls return 3 **distinct** `session_id`s (baggage session isolation working)
+- [ ] HoneyHive Studio shows all 3 sessions within 15s of curl
+- [ ] Each session's spans are classified as `chain` / `model` / `tool` — **not** all fall through to `tool` (event_type priority detection working)
+- [ ] `cdk destroy` exits 0. Confirm in CloudFormation console that stack status is `DELETE_COMPLETE` and no resources remain in Lambda, IAM, API Gateway, or CloudWatch Logs.
+
+## Screenshot checklist (Phase B fallback artifacts)
+
+Stored under `docs/fallback/`.
+
+| # | File | What it shows |
+|---|------|---------------|
+| 00 | `00-cdk-synth.txt` | Text output of `cdk synth --quiet` (archived for Phase A verification) |
+| 00 | `00-cdk-diff.txt` | Text output of `cdk diff` against empty env (Phase A) |
+| 01 | `01-cdk-deploy-output.png` | Terminal during/after `cdk deploy`, ApiUrl visible |
+| 02 | `02-curl-response.png` | Terminal showing 3 curls + responses with distinct session_urls |
+| 03 | `03-studio-session-list.png` | HoneyHive Studio session list filtered to last 5 min, 3 rows |
+| 04 | `04-studio-trace-spans.png` | Single session expanded, agent/model/tool spans visible |
+| 05 | `05-cdk-destroy.png` | Terminal after clean `cdk destroy`, 0 errors |
+
+If any of these can't be captured live during the demo, use the stored fallback to walk the audience through the expected output.
+
+## Rollback & common failure modes
+
+**`docker exited with status 125` during synth/deploy.**
+Docker Desktop is not running. Start it (`open -a Docker`), wait ~30s, retry.
+
+**`ValidationException: ... on-demand throughput isn't supported`.**
+`MODEL_ARN` points at a foundation-model ARN for a model that requires an inference profile (Claude 4.5, Nova). Switch to an `application-inference-profile/*` ARN. See step 6.
+
+**`AccessDeniedException` on `bedrock:InvokeModel`.**
+Either (a) model access not granted for your chosen model in the region (fix in Bedrock console), or (b) IAM policy missing the `application-inference-profile/*` resource pattern (check `stacks/strands_bedrock_lambda_stack.py`; default stack already includes it).
+
+**Deploy succeeds; curl returns HTTP 500 with `"cold-start init failed"`.**
+Lambda init raised. Cold-start guard returns structured 500. Check `/aws/lambda/<fn>` CloudWatch log group for the underlying error — most likely `HONEYHIVE_API_KEY` secret not in this region, or `HONEYHIVE_PROJECT` env missing.
+
+**Curl succeeds but no trace in Studio.**
+1. Confirm the secret exists in the deploy region: `aws secretsmanager get-secret-value --secret-id honeyhive/api-key --region us-east-1`.
+2. Confirm `HONEYHIVE_PROJECT` value matches an actual project in your workspace (typos silently drop).
+3. For self-hosted HoneyHive, pass `-c honeyhive_server_url=https://your-host` at deploy.
+
+**Spans all classified as `tool` in Studio.**
+HoneyHive SDK too old. Confirm `lambda/requirements.txt` is pinned to `honeyhive==1.0.0rc21` or newer; this rc adds the event_type priority detection that maps Strands GenAI ops correctly. Redeploy after updating.
+
+**Session IDs bleed across invocations.**
+SDK too old. Same pin fix as above — `rc10+` ships the baggage-based session isolation.
+
+**`cdk destroy` leaves orphan resources.**
+Check:
+- CloudWatch log group (`/aws/lambda/<fn>`) — stack uses `RemovalPolicy.DESTROY`, so this should be gone. If not, delete manually.
+- Secrets Manager secret — intentionally NOT owned by the stack; delete separately (step 13).
+- Bedrock application inference profile — NOT created by the stack. Delete from the Bedrock console only if you created it for this demo.
+
+## After the deploy test
+
+- Post results (success or failures) as a Linear comment on [HHAI-4971](https://linear.app/honeyhive/issue/HHAI-4971).
+- Any new friction discovered → open a follow-up on the README (HHAI-4969) to harden the *Common errors* section.
+- When HHAI-4973 dry-runs this playbook, they should be able to reproduce the outputs step-for-step. If any step diverges, that's a playbook bug — fix here, not in the dry-run notes.

--- a/strands-bedrock-lambda-cdk-cookbook/docs/fallback/00-cdk-synth.txt
+++ b/strands-bedrock-lambda-cdk-cookbook/docs/fallback/00-cdk-synth.txt
@@ -1,0 +1,54 @@
+Bundling asset StrandsBedrockLambdaStack/HandlerFunction/Code/Stage...
+docker: Cannot connect to the Docker daemon at unix:///Users/dhruvsingh/.docker/run/docker.sock. Is the docker daemon running?.
+See 'docker run --help'.
+[1;35mjsii.errors.JavaScriptError[0m: [35m
+  «FailedToBundleAsset» Failed to bundle asset StrandsBedrockLambdaStack/HandlerFunction/Code/Stage, bundle output is located at /Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/cdk.out/asset.b3076bb987d549c67b80919cad16b305a751e9c3274d976217628317cf89557d-building: CommandExecutionFailed: docker exited with status 125
+  --> Command: docker run --rm -u "501:20" -v "/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/lambda:/asset-input:delegated" -v "/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/cdk.out/asset.b3076bb987d549c67b80919cad16b305a751e9c3274d976217628317cf89557d-building:/asset-output:delegated" -w "/asset-input" "public.ecr.aws/sam/build-python3.12" bash -c "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
+      ...new Function2 in aws-cdk-lib...
+      at Kernel._Kernel_create (/private/var/folders/rg/p8zz76_d14bf_zl146p4yblw0000gn/T/tmppjt6fqxe/lib/program.js:1:61100)
+  Relates to construct:
+      <.> (aws-cdk-lib.App)
+       └─ StrandsBedrockLambdaStack (aws-cdk-lib.Stack)
+           └─ HandlerFunction (aws-cdk-lib.aws_lambda.Function)
+               └─ Code (aws-cdk-lib.aws_s3_assets.Asset)
+                   └─ Stage (aws-cdk-lib.AssetStaging)[0m
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/app.py"[0m, line [35m8[0m, in [35m<module>[0m
+    [31mStrandsBedrockLambdaStack[0m[1;31m([0m
+    [31m~~~~~~~~~~~~~~~~~~~~~~~~~[0m[1;31m^[0m
+        [1;31mapp,[0m
+        [1;31m^^^^[0m
+        [1;31m"StrandsBedrockLambdaStack",[0m
+        [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+    [1;31m)[0m
+    [1;31m^[0m
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/jsii/_runtime.py"[0m, line [35m118[0m, in [35m__call__[0m
+    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/stacks/strands_bedrock_lambda_stack.py"[0m, line [35m57[0m, in [35m__init__[0m
+    handler_fn = lambda_.Function(
+        self,
+    ...<24 lines>...
+        log_group=log_group,
+    )
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/jsii/_runtime.py"[0m, line [35m118[0m, in [35m__call__[0m
+    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/aws_cdk/aws_lambda/__init__.py"[0m, line [35m33978[0m, in [35m__init__[0m
+    [31mjsii.create[0m[1;31m(self.__class__, self, [scope, id, props])[0m
+    [31m~~~~~~~~~~~[0m[1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/jsii/_kernel/__init__.py"[0m, line [35m334[0m, in [35mcreate[0m
+    response = self.provider.create(
+        CreateRequest(
+    ...<7 lines>...
+        )
+    )
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/jsii/_kernel/providers/process.py"[0m, line [35m365[0m, in [35mcreate[0m
+    return [31mself._process.send[0m[1;31m(request, CreateResponse)[0m
+           [31m~~~~~~~~~~~~~~~~~~[0m[1;31m^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+  File [35m"/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/.venv/lib/python3.14/site-packages/jsii/_kernel/providers/process.py"[0m, line [35m342[0m, in [35msend[0m
+    raise RuntimeError(resp.error) from JavaScriptError(resp.stack)
+[1;35mRuntimeError[0m: [35mFailed to bundle asset StrandsBedrockLambdaStack/HandlerFunction/Code/Stage, bundle output is located at /Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/cdk.out/asset.b3076bb987d549c67b80919cad16b305a751e9c3274d976217628317cf89557d-building: CommandExecutionFailed: docker exited with status 125
+--> Command: docker run --rm -u "501:20" -v "/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/lambda:/asset-input:delegated" -v "/Users/dhruvsingh/honeyhive/cookbook/strands-bedrock-lambda-cdk-cookbook/cdk.out/asset.b3076bb987d549c67b80919cad16b305a751e9c3274d976217628317cf89557d-building:/asset-output:delegated" -w "/asset-input" "public.ecr.aws/sam/build-python3.12" bash -c "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"[0m
+python3 app.py: Subprocess exited with error 1

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/handler.py
@@ -23,6 +23,7 @@ Three patterns matter here; a reader poking at this later should know why:
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 
@@ -81,7 +82,18 @@ def handler(event, context):
     if _INIT_ERROR or _tracer is None or _agent is None:
         return {"error": "cold-start init failed", "detail": _INIT_ERROR}
 
-    prompt = (event or {}).get("prompt") or "What is 17 * 23?"
+    # HTTP API v2 delivers the POST body as a JSON string in event["body"];
+    # direct Lambda invokes put keys at the event root. Support both.
+    event = event or {}
+    body_raw = event.get("body")
+    if isinstance(body_raw, str) and body_raw:
+        try:
+            body = json.loads(body_raw)
+        except json.JSONDecodeError:
+            body = {}
+    else:
+        body = {}
+    prompt = body.get("prompt") or event.get("prompt") or "What is 17 * 23?"
     session_name = f"lambda-{uuid.uuid4().hex[:8]}"
 
     # Reset per-invocation agent state — see module docstring, item 3(b)

--- a/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
+++ b/strands-bedrock-lambda-cdk-cookbook/lambda/requirements.txt
@@ -1,6 +1,29 @@
 # Lambda runtime deps — bundled into the Lambda deployment package by CDK.
 # Keep this separate from the repo-root requirements.txt, which is CDK-synth deps only.
+#
+# Exact pins (HHAI-4970). This is a hackathon template — reproducibility matters
+# more than flexibility. Why these versions:
+#
+#   honeyhive==1.0.0rc21
+#     - session_id baggage isolation (rc10+): get_baggage("honeyhive.session_id")
+#       in tracer/core/operations.py prevents warm-Lambda session bleed across
+#       users (customer-nationwide, 2025-10-28).
+#     - event_type priority detection in HoneyHiveSpanProcessor: raw >
+#       honeyhive_event_type > gen_ai.operation.name > openinference.span.kind >
+#       span-name patterns. Maps Strands GenAI ops (invoke_agent → chain,
+#       execute_tool → tool, chat → model) so Strands spans are categorized
+#       correctly instead of falling through to the default "tool". SDK-side
+#       complement to hive-kube#3239.
+#     - application-inference-profile ARNs: handled transparently by boto3 +
+#       Bedrock converse(); no SDK-side change needed.
+#
+#   strands-agents==1.26.0
+#     Version the handler was authored/tested against.
+#
+#   boto3==1.42.47
+#     Pinned for reproducibility. Lambda runtime provides its own boto3, but an
+#     exact pin keeps the deployed layer deterministic.
 
-strands-agents>=1.0.0,<2.0.0
-honeyhive>=1.0.0rc20  # Pin to be tightened in HHAI-4970 once the rc with Strands event_type priority lands
-boto3>=1.34.0
+honeyhive==1.0.0rc21
+strands-agents==1.26.0
+boto3==1.42.47


### PR DESCRIPTION
# HHAI-4971 — Phase A: synth verification + deploy playbook

**Status: DRAFT.** Phase A artifacts only. Phase B (real AWS deploy + verification of sc3/sc4/sc7) is blocked on the AWS sandbox-profile question outstanding on parent issue [HHAI-4941](https://linear.app/honeyhive/issue/HHAI-4941). Reviewer can review the playbook independently of Phase B.

Linear sub-issue: [HHAI-4971](https://linear.app/honeyhive/issue/HHAI-4971)

## Stack

This PR is the tip of the strands-bedrock-lambda-cdk cookbook stack:

```
main
  └─ #30 hhai-4966-cdk-scaffold
       ├─ #31 hhai-4968-cdk-stack
       │    └─ #33 hhai-4969-readme
       │         └─ #34 hhai-4970-version-pins  (merged here as 4b44c24)
       └─ #32 hhai-4967-lambda-handler
            └─ #34 hhai-4970-version-pins
                 └─ THIS PR  (hhai-4971-deploy-test)
```

Base is set to `hhai-4969-readme` per the stack convention. The diff against that base shows three upstream commits that belong to #34 (honeyhive SDK / strands / boto3 pins) plus this PR's own commit. After #30/#31/#32/#33/#34 merge upstream, this PR's base will rebase to `main` and the diff will narrow to just the Phase A docs.

## What Phase A delivers

**`strands-bedrock-lambda-cdk-cookbook/docs/deploy-playbook.md`** — end-to-end ops runbook for the strands-bedrock-lambda-cdk demo. The README covers the user-facing flow; this playbook adds the ops detail:

- AWS profile pre-flight (sandbox-only — explicit warning to never point at customer or production accounts)
- 13 numbered steps from clean clone through `cdk destroy`
- Verification checklist (sc3/sc4/sc7 — distinct session_ids, span classification, 15s trace SLA)
- Screenshot checklist for the NW accelerator demo fallback artifacts (`docs/fallback/00-…05-…`)
- "Rollback & common failure modes" — Docker daemon down, model-access errors, on-demand throughput errors, span-classification regressions, baggage isolation regressions, orphan-resource cleanup

**`strands-bedrock-lambda-cdk-cookbook/docs/fallback/00-cdk-synth.txt`** — captured CDK synth output. *Note:* the captured output documents the **docker-not-running failure mode** (the exact failure described in the playbook's Rollback section, `docker exited with status 125`). It is *not* a successful synth log. See the gaps list below — re-capture is part of Phase B remediation.

## What Phase B still needs (and why this is a draft)

1. **Real AWS deploy in HoneyHive sandbox.** Blocked on Dhruv specifying which AWS profile on the demo machine is the HoneyHive sandbox account (open question on parent issue [HHAI-4941](https://linear.app/honeyhive/issue/HHAI-4941)). The playbook explicitly forbids deploying without confirmation — wrong account = accidental provisioning in a customer or production environment.
2. **Re-capture `00-cdk-synth.txt` with Docker running.** Current archived output is a Docker-down failure trace. Phase B should re-run `cdk synth --quiet` cleanly and overwrite this file.
3. **Capture `00-cdk-diff.txt`.** Referenced in the playbook's screenshot checklist but not yet generated.
4. **Capture fallback screenshots 01–05** per playbook table:
   - `01-cdk-deploy-output.png` — terminal during/after `cdk deploy`, ApiUrl visible
   - `02-curl-response.png` — three curls + responses with distinct session_urls
   - `03-studio-session-list.png` — HoneyHive Studio session list filtered to last 5 min, 3 rows
   - `04-studio-trace-spans.png` — single session expanded, agent/model/tool spans visible
   - `05-cdk-destroy.png` — terminal after clean `cdk destroy`, 0 errors
5. **Verify success criteria sc3/sc4/sc7:**
   - sc3: 15s trace SLA (curl complete → trace visible in Studio)
   - sc4: distinct `session_id` across 3 back-to-back invocations (baggage isolation)
   - sc7: span event_type classification (`chain` / `model` / `tool`, not all `tool`)

## Test plan

- [ ] Reviewer reads `docs/deploy-playbook.md` and confirms it is followable end-to-end without ambiguity
- [ ] Reviewer confirms the playbook's pre-flight warning about sandbox-profile selection is sufficiently strong for a public cookbook (this is the safety gate before any deploy)
- [ ] Reviewer confirms the playbook's screenshot checklist matches the desired Phase B fallback artifact set
- [ ] Phase B (separate follow-up): all items in "What Phase B still needs" above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
