### PR TITLE
Add latest HoneyHive agent skills

### DIFF
--- a/.agents/skills/honeyhive-alert-root-cause/SKILL.md
+++ b/.agents/skills/honeyhive-alert-root-cause/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: honeyhive-alert-root-cause
+description: >
+  Decode a HoneyHive Discover URL, query the flagged sessions and their trace trees,
+  classify each finding as a true or false positive with evidence, and recommend
+  specific guardrails (hooks, evaluator changes, prompt additions) to prevent recurrence.
+license: MIT
+metadata:
+  version: "0.1.0"
+  homepage: https://docs.honeyhive.ai
+---
+
+# Debug Alert Triggers via Discover URLs
+
+When the user pastes a HoneyHive Discover URL, decode it and run a full investigation.
+
+**Prerequisites:** The HoneyHive CLI must be installed and authenticated. See [`../honeyhive-cli/SKILL.md`](../honeyhive-cli/SKILL.md) for install, discovery, and sanity-check instructions. Run the CLI sanity check before proceeding.
+
+## Reference Docs
+
+- [Semantic Conventions Reference](https://docs.honeyhive.ai/v2/sdk-reference/semconv-reference) — canonical event schema, root fields, the seven structured buckets, and how attributes trigger UI behaviors
+- [Framework Attribute Mapping](https://docs.honeyhive.ai/v2/sdk-reference/semconv-alignment) — how OpenTelemetry GenAI, OpenInference, and Traceloop attributes normalize into HoneyHive's schema
+- [Explore Trace Data](https://docs.honeyhive.ai/v2/tracing/query-data) — programmatic query patterns, filter syntax, and pagination
+
+## HoneyHive API Reference
+
+This section contains the minimum API surface needed for alert investigations. For the full schema details, see the docs linked above.
+
+### Event Schema
+
+Every event has root fields plus seven structured buckets:
+
+```json
+{
+  "event_id": "uuid",
+  "session_id": "uuid",
+  "parent_id": "uuid or null",
+  "event_type": "session | model | tool | chain",
+  "event_name": "human-readable span label",
+  "source": "prod | dev | staging",
+  "start_time": 1711234567000,
+  "end_time": 1711234568000,
+  "duration": 1000,
+  "inputs": {},
+  "outputs": {},
+  "error": "string or null",
+  "config": {},
+  "metadata": {},
+  "metrics": {},
+  "feedback": {},
+  "user_properties": {},
+  "children_ids": []
+}
+```
+
+**Key buckets for investigations:**
+- **`inputs`**: prompts, queries, messages. Look for `chat_history` (message thread), `query` (search/retrieval), `parameters`/`tool_arguments` (function params).
+- **`outputs`**: completions, responses. Look for `content` (text), `tool_calls` (function calls requested by the model), `role` (chat message role).
+- **`config`**: model/tool settings. `model`, `provider`, `temperature`, `tools` (function definitions), `template` (prompt template).
+- **`metadata`**: framework info, token counts. `prompt_tokens`/`completion_tokens`/`total_tokens`, `cost`, `finish_reason`, `agent_name`, `span_kind`.
+- **`metrics`**: evaluator scores — the alert's monitored metric typically lives here. All sub-keys render as "Automated Evaluations" in the UI.
+- **`feedback`**: human or automated annotations.
+
+**`event_type` determines UI rendering:**
+| Value | Meaning | What to look for |
+|-------|---------|------------------|
+| `session` | Root span grouping an invocation | `metadata.num_events`, `metadata.cost`, `metadata.total_tokens` |
+| `model` | LLM call | `inputs.chat_history`, `outputs.content`, `outputs.tool_calls`, `config.model` |
+| `tool` | Tool/function execution | `inputs.parameters`, `outputs`, `error` |
+| `chain` | Orchestration (sub-agents, routing, retrieval) | `children_ids` to follow nested events |
+
+### Querying Events
+
+**CLI-first** (preferred):
+
+```bash
+# Query sessions matching filters within the alert time window
+honeyhive events search \
+  --filters '[{"field":"event_type","operator":"is","value":"session","type":"string"}]' \
+  --date-range '{"start_time":"2025-06-01T00:00:00Z","end_time":"2025-06-02T00:00:00Z"}' \
+  --limit 100 --page 1
+
+# Query child events for a specific session
+honeyhive events search \
+  --filters '[{"field":"session_id","operator":"is","value":"<SESSION_ID>","type":"string"}]' \
+  --date-range '{"start_time":"2025-06-01T00:00:00Z","end_time":"2025-06-02T00:00:00Z"}' \
+  --limit 500 --page 1
+```
+
+Use `honeyhive events search --show-argument-schema filters` and `honeyhive events search --show-argument-schema date-range` to inspect the full schemas.
+
+**API fallback** (when CLI is unavailable):
+
+```
+POST /v1/events/search
+Authorization: Bearer $HH_API_KEY
+Content-Type: application/json
+
+{
+  "filters": [
+    { "field": "event_type", "operator": "is", "value": "session", "type": "string" }
+  ],
+  "dateRange": { "start_time": "ISO 8601 timestamp", "end_time": "ISO 8601 timestamp" },
+  "limit": 100,
+  "page": 1
+}
+```
+
+**Important:** `dateRange` is a **top-level field** with `start_time`/`end_time` (ISO 8601) — do NOT put dates inside the `filters` array. Project scoping comes from the bearer API key, not a body field.
+
+Filter operators: `is`, `is not`, `contains`, `not contains`, `exists`, `not exists`, `greater than`, `less than`
+
+Filter types: `string`, `number`, `boolean`, `datetime`
+
+Max limit per page: 1000.
+
+### Fetching a Session Tree
+
+**CLI-first:**
+
+```bash
+honeyhive events search \
+  --filters '[{"field":"session_id","operator":"is","value":"<SESSION_ID>","type":"string"}]' \
+  --date-range '{"start_time":"<ALERT_START>","end_time":"<ALERT_END>"}' \
+  --limit 500 --page 1
+```
+
+**API fallback:**
+
+```
+GET /v1/sessions/{session_id}
+```
+
+Returns the nested event tree with children. Note: this endpoint requires org-scoped auth and will 401 with a project-scoped bearer API key. Prefer the CLI or `POST /v1/events/search` with a `session_id` filter.
+
+## Decoding the URL
+
+Discover URLs look like: `/discover/new?config=<base64>`
+
+To decode:
+```bash
+echo '<base64 string>' | base64 -d | python3 -m json.tool
+```
+
+The decoded config object has this shape:
+```json
+{
+  "type": "sessions | completions | events",
+  "eventName": "specific event name (omitted if generic)",
+  "filters": [{"field": "...", "value": "...", "operator": "...", "type": "..."}],
+  "metric": "field name being monitored",
+  "func": "avg | sum | count | min | max | median | percentile_90 | percentile_95 | percentile_99",
+  "dateRange": {"$gte": "ISO timestamp", "$lte": "ISO timestamp"},
+  "bucketing": "minute | hour | day | week"
+}
+```
+
+## Deriving the Trigger Condition
+
+The Discover URL config may not include the threshold filter directly. Derive it from the config:
+
+- **`metric`** is the field being monitored (e.g., `metrics.unsafe_command_severity`)
+- **`func`** is the aggregation (e.g., `avg`, `count`)
+- The alert triggered because this metric crossed a threshold
+- If the config already has a filter on the metric (common), use that filter directly
+- If not, add one: `{"field": "<metric>", "operator": "greater than", "value": 0, "type": "number"}`
+
+## Investigation Steps
+
+After decoding:
+
+1. **Summarize the alert context**: what metric, what filters, what time window, what aggregation function
+
+2. **Query HoneyHive for matching sessions** in that time window.
+
+   CLI-first:
+   ```bash
+   honeyhive events search \
+     --filters '[{"field":"event_type","operator":"is","value":"session","type":"string"},{"field":"<metric>","operator":"greater than","value":"0","type":"number"}]' \
+     --date-range '{"start_time":"<ALERT_START>","end_time":"<ALERT_END>"}' \
+     --limit 100 --page 1
+   ```
+
+   API fallback — `POST /v1/events/search` with:
+   - `dateRange` as a **top-level field** with `start_time`/`end_time` (ISO 8601) — do NOT put dates in the filters array
+   - Filter `type` must be one of: `string`, `number`, `boolean`, `datetime` (not `float` or `int`)
+   - Map config filters directly into the request filters, plus add `event_type: session`
+
+3. **For each flagged session**, fetch all child events using a `session_id` filter.
+   Do NOT use `GET /v1/sessions/<id>` — it requires org-scoped auth and will 401 with a project-scoped bearer API key.
+   Set `limit: 500` to get the full event tree.
+
+4. **Walk the event tree** to identify the behavior that triggered the alert:
+
+   Use the `event_type` and `event_name` fields to navigate. The exact event names vary by source (Claude Code, Devin, custom agents, RAG pipelines, etc.) — don't assume a fixed set.
+
+   General strategy by `event_type`:
+   - **`session`**: the root event. `metadata` typically has session-level context (name, config, user properties). Start here to understand what the session was doing.
+   - **`model`**: LLM calls. `inputs` has the prompt/messages, `outputs` has the completion. Check for hallucinations, policy violations in generated content, or unexpected tool-use requests.
+   - **`tool`**: tool/function calls. `inputs` has the parameters the LLM requested, `outputs` has the result. This is where most unsafe *actions* surface — shell commands, API calls, file writes, database queries.
+   - **`chain`**: orchestration events (sub-agents, routing, retrieval chains). `children_ids` links to the nested events. Follow these to find which step in a multi-step workflow caused the alert.
+
+   For each event, check:
+   - `error` field — non-null means something failed
+   - `metrics` — the alert's monitored metric likely lives here
+   - `inputs` / `outputs` — the actual content that may have triggered the evaluator
+
+5. **Classify each finding**, distinguishing true positives from false positives:
+   - **True positive / critical**: the flagged behavior is genuinely dangerous or violates policy (e.g., destructive commands, data exfiltration, unauthorized API calls, PII in outputs)
+   - **True positive / low severity**: technically risky but defensible in context (e.g., a destructive action on a temp resource, an elevated-permission call that was authorized)
+   - **False positive / string literal**: the flagged pattern appears inside a string constant, evaluator definition, test fixture, or documentation — the agent was *writing about* the pattern, not *executing* it
+   - **False positive / safe variant**: the flagged pattern matches superficially but the actual behavior is safe (e.g., a partial keyword match, a scoped-down version of a dangerous operation)
+
+   **To distinguish**: look at where the pattern appears in the event. Is it in `inputs.command` / `outputs.text` at the top level (likely real), or nested inside a quoted string, code block, or configuration object being *written* rather than *executed*?
+
+6. **Recommend guardrails**:
+   - Pre-execution hooks or middleware that block specific patterns before they run
+   - Prompt-level instructions or system message additions to prefer safer alternatives
+   - Evaluator refinements to reduce false positives (e.g., distinguish between executing a pattern vs. writing code that contains it)
+
+## Output Format
+
+Structure your response as:
+
+### Alert Context
+- Metric: ...
+- Time window: ... to ...
+- Filters: ...
+
+### Flagged Sessions (N found)
+
+For each:
+- **Session ID**: `...` | **Verdict**: true positive / false positive
+- **What happened**: one-line summary
+- **Flagged behavior**: the specific events/actions that triggered the alert
+- **Context**: why this behavior occurred (from surrounding events in the trace)
+- **Risk level**: critical / high / medium / low
+
+### Recommendations
+- Guardrails to add
+- Evaluator refinements
+- Patterns to whitelist

--- a/.agents/skills/honeyhive-alert-root-cause/success.md
+++ b/.agents/skills/honeyhive-alert-root-cause/success.md
@@ -1,0 +1,41 @@
+# Alert investigation success criteria
+
+[`SKILL.md`](SKILL.md) defines the investigation workflow. This page is the rubric for grading whether an investigation was thorough and actionable. A mechanically-correct query that misclassifies findings or produces vague recommendations is not done.
+
+A well-executed alert investigation has:
+
+## Correct URL decoding
+
+- The base64 config was decoded without errors.
+- All fields were extracted: type, filters, metric, func, dateRange, bucketing.
+- The trigger condition was derived correctly (metric + threshold filter).
+- The alert context summary matches the decoded config — no fields dropped or misinterpreted.
+
+## Accurate session querying
+
+- Filters match the alert config (metric filter, event_type, any additional filters from the URL).
+- dateRange was passed as a top-level field, not inside the filters array.
+- Filter types are correct (string, number, boolean, datetime — not float or int).
+- All matching sessions were retrieved (pagination handled if results exceed one page).
+
+## Complete trace tree walking
+
+- Every flagged session had its child events fetched (limit 500, not truncated at default).
+- The event tree was walked to leaf events — not just the session root.
+- Tool events had their inputs/outputs inspected for the monitored pattern.
+- Surrounding events were checked to understand the context that led to the flagged behavior.
+- Session-level metadata was noted for context.
+
+## Accurate classification
+
+- Each finding is classified as true positive or false positive with evidence.
+- String-literal false positives are correctly identified: patterns that appear inside generated content, evaluator definitions, or test fixtures are not flagged as executed behavior.
+- Severity levels are calibrated relative to the actual risk (destructive + irreversible = critical, scoped + recoverable = low).
+- The classification distinguishes between the agent performing a flagged action vs. producing output that contains the flagged pattern.
+
+## Actionable recommendations
+
+- Recommendations are specific: exact hook patterns, evaluator regex changes, or prompt additions — not generic advice.
+- False-positive reduction suggestions target the specific pattern that caused the misclassification.
+- Guardrail recommendations include both blocking (pre-execution hooks) and detection (evaluator refinements).
+- Whitelist suggestions are scoped narrowly to the safe variant identified, not broad exclusions.

--- a/.agents/skills/honeyhive-cli/SKILL.md
+++ b/.agents/skills/honeyhive-cli/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: honeyhive-cli
+description: >
+  HoneyHive CLI install, discovery, and usage reference. Shared by
+  honeyhive-instrument, honeyhive-evaluate, and honeyhive-improve skills.
+  Use to install the CLI, discover commands, inspect schemas, and file
+  doc-gap issues.
+license: MIT
+metadata:
+  version: "0.1.0"
+  homepage: https://docs.honeyhive.ai
+---
+
+# HoneyHive CLI
+
+## Install
+
+- **macOS:** `brew tap honeyhiveai/tap && brew install honeyhive`
+- **Linux / CI / WSL:** `curl -fsSL https://github.com/honeyhiveai/honeyhive-cli/releases/latest/download/install.sh | sh` (requires glibc — works on Ubuntu, Debian, Fedora, RHEL, WSL; does **not** work on Alpine/musl)
+
+## Discovery
+
+- `honeyhive --help` — top-level namespaces and global flags
+- `honeyhive <namespace> --help` — subcommands (e.g. `honeyhive events --help`)
+
+## Schema Introspection
+
+When a command accepts file input or structured arguments:
+
+- `honeyhive <command> --show-file-schema` — JSON schema for file-based input
+- `honeyhive <command> --show-argument-schema <argument-name>` — JSON schema for a specific structured argument (use the argument name without the `--` prefix)
+
+Use these instead of guessing flags or payload shapes.
+
+## Sanity Check
+
+Before any skill that depends on HoneyHive, confirm the CLI is working and credentials are valid. Run these checks in order; stop on first failure.
+
+1. **CLI installed?** `honeyhive --help` must succeed. If not, install per the instructions above.
+2. **Env vars set?** `HH_API_KEY` and `HH_DATA_PLANE_URL` must be in the environment (never hardcoded in source). If missing, direct the user to their project settings page to find both values: `https://app.us.honeyhive.ai/settings/project/keys` for multi-tenant, or `https://app.<tenant>.us.honeyhive.ai/settings/project/keys` for dedicated deployments (see [references/dedicated-deployments.md](references/dedicated-deployments.md)).
+3. **API reachable?** Run a single authenticated probe:
+   ```bash
+   honeyhive events search --filters '[]' --limit 1 --page 1
+   ```
+   A valid JSON response (array or `{"events":[...]}`) = good. An error or auth failure = stop and surface. If the CLI is not installed, fall back to curl — see [references/network-validation.md](references/network-validation.md) for the exact command and status-code table.
+On failure at any step, surface the exact error and stop. Do not proceed into skill-specific work with broken credentials or connectivity.
+
+The sanity check produces: `status` (pass/fail), `hh_data_plane_url`, `deployment_type`, and `probe_method`. The **calling skill** decides whether and where to persist these (e.g. `honeyhive-instrument` writes `state/network-validation.json`; other skills may not need state files).
+
+## Doc-Gap Filing
+
+When a skill hits missing CLI coverage, incomplete docs, or an unsupported framework/integration, file automatically:
+
+```bash
+gh issue create --repo honeyhiveai/skills \
+  --title "Doc gap: <short description>" \
+  --body "**Skill:** <skill-name>
+**CLI/SDK version:** <detected version>
+**Framework:** <framework and version>
+**Gap:** <what is missing>
+**Workaround:** <what was done instead>"
+```
+
+Report the created issue URL to the user.

--- a/.agents/skills/honeyhive-cli/references/dedicated-deployments.md
+++ b/.agents/skills/honeyhive-cli/references/dedicated-deployments.md
@@ -1,0 +1,29 @@
+# Dedicated / self-host deployments
+
+Most code samples assume the multi-tenant default `https://api.dp1.us.honeyhive.ai`. Dedicated and self-host customers have their own host — silently defaulting to multi-tenant means spans fail auth.
+
+## Detecting the deployment type
+
+Signals (any one is enough):
+
+- Existing code passes `server_url=...` (Python) or `dataPlaneUrl: ...` (TS) with a non-default host.
+- `HH_DATA_PLANE_URL` (TS/CLI) or `HH_API_URL` (Python) is set in `.env`, deploy config, k8s manifest, or CI secrets.
+- The user mentions a custom hostname or tenant name.
+- Their HoneyHive UI lives at `app.<tenant>.us.honeyhive.ai` — the API host mirrors it (`api.<tenant>.us.honeyhive.ai`).
+
+If you cannot confidently determine the host: **ask the user**. Do not default by inference.
+
+## URL patterns
+
+| Deployment | API host | UI host |
+|---|---|---|
+| Multi-tenant (default) | `https://api.dp1.us.honeyhive.ai` | `https://app.us.honeyhive.ai` |
+| Dedicated | `https://api.<tenant>.us.honeyhive.ai` | `https://app.<tenant>.us.honeyhive.ai` |
+| Self-host | Customer-defined (e.g. `https://honeyhive.<corp-domain>`) | Customer-defined |
+
+## Common failure modes
+
+- **401/403**: API key minted on a different deployment than the configured URL. Verify both came from the same workspace UI.
+- **Spans silently dropping**: SDK defaulted to multi-tenant because `server_url=` (Python) or `dataPlaneUrl:` (TS) was not passed. Always pass explicitly.
+- **TLS errors**: Self-host may use a custom CA — see [network-validation.md](network-validation.md) Step 3.
+- **OTel collector silently exporting to default**: The OTLP exporter `endpoint:` doesn't auto-read the user's deployment URL. Set it to `${env:HH_DATA_PLANE_URL}/opentelemetry/v1/traces` (or `${env:HH_API_URL}/...` for Python users) explicitly. This failure is silent — only caught with verbose exporter logging.

--- a/.agents/skills/honeyhive-cli/references/network-validation.md
+++ b/.agents/skills/honeyhive-cli/references/network-validation.md
@@ -1,0 +1,73 @@
+# Network validation — curl fallback
+
+This reference covers the **curl fallback** for when the HoneyHive CLI is not installed. The primary path is the [honeyhive-cli sanity check](../SKILL.md#sanity-check) which runs `honeyhive events search` directly.
+
+> **Hard rule: do not proceed to runtime validation until reachability succeeds.** A wrong URL, wrong key, or blocked egress means every later step is rebuilding sand.
+
+## Environment variables
+
+- `HH_API_KEY` — project-scoped API key. **Must come from an env var, never a literal in code.**
+- `HH_DATA_PLANE_URL` — deployment host. Multi-tenant default: `https://api.dp1.us.honeyhive.ai`; dedicated and self-host customers have their own. See [`dedicated-deployments.md`](dedicated-deployments.md).
+
+If either is missing, direct the user to https://app.us.honeyhive.ai/settings/project/keys.
+
+## Curl reachability check (fallback when CLI is not installed)
+
+```bash
+curl -sS -o /dev/null -w "HTTP %{http_code}\n" \
+  -X POST \
+  -H "Authorization: Bearer $HH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"filters":[],"limit":1,"page":1}' \
+  "${HH_DATA_PLANE_URL:-$HH_API_URL}/v1/events/search"
+```
+
+Interpretation:
+
+| Result | Meaning | Action |
+|---|---|---|
+| `HTTP 200` | URL reachable, key valid | Proceed to Phase 0 runtime validation |
+| `HTTP 401` | URL reachable, key invalid for this deployment | Stop — the key was minted for a different workspace, or it was revoked. Ask the user to confirm key + URL came from the same deployment UI |
+| `HTTP 403` | URL reachable, key lacks scope | Stop — confirm the key is project-scoped, not personal-access |
+| `HTTP 404` | Wrong URL path or wrong host | Stop — verify `HH_DATA_PLANE_URL` is correct (no trailing slash, correct subdomain) |
+| `HTTP 000` / connection error | Egress blocked, DNS failure, or wrong host entirely | Stop — surface to the user; their network team may need to allow `:443` outbound to the host |
+| `curl: (60)` SSL cert error | Self-host using a custom CA | See TLS cert chain section below |
+
+Run the check exactly once. Do **not** retry on failure — surface the exact `curl` output and stop.
+
+## TLS cert chain (self-host only)
+
+If the user is on self-host and `curl` returns SSL errors, the runtime needs a custom CA bundle:
+
+```bash
+curl -v "${HH_DATA_PLANE_URL:-$HH_API_URL}/v1/events/search" 2>&1 | grep -E 'SSL|TLS|verify|certificate'
+```
+
+If "self signed certificate" or "unable to get local issuer certificate" appears, surface to the user. The fix depends on the deployment type:
+
+**Self-hosted deployments:** The TLS certificate is issued for the customer's own domain. The customer's internal CA that signed that certificate must be trusted by the runtime where the SDK or collector runs. Ask the infrastructure or security team for that CA certificate bundle (often a `.pem` or `.crt` file). In corporate environments, check if the package manager or IT department distributes it (e.g., `/etc/ssl/certs/ca-certificates.crt` on Debian, or a custom path set by IT).
+
+**Multi-tenant / dedicated deployments:** HoneyHive uses publicly trusted certificates (Let's Encrypt / AWS ACM), so no custom CA is needed under normal circumstances. However, corporate proxies that MITM outbound TLS connections will re-sign traffic with the proxy's own CA — in that case the proxy's CA certificate must be trusted by the runtime, just like a self-host CA would be.
+
+To surface the exact hostname the network team needs to inspect or whitelist:
+
+```bash
+echo "${HH_DATA_PLANE_URL:-$HH_API_URL}" | sed 's|https://||'
+```
+
+Give the network team that hostname so they can verify the certificate chain, add firewall rules for `:443` egress, and — if a MITM proxy is in the path — confirm which CA the proxy uses to re-sign.
+
+Configuration by runtime:
+- For Python apps: `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` env var pointing at the custom CA.
+- For Node apps: `NODE_EXTRA_CA_CERTS` env var.
+- For native OTel collectors: the exporter's `tls.ca_file` config.
+
+Do not silently proceed with TLS verification disabled — surface as a finding and let the user wire the cert chain.
+
+## Common failures (and how to read them)
+
+- **401 with HH_DATA_PLANE_URL pointing at a dedicated tenant but key minted on multi-tenant** (or vice versa). Most common cause of "I copied the snippet from docs and it doesn't work" for dedicated customers. Confirm key + URL came from the same UI.
+- **`curl` returns 200 but instrumentation later silently drops spans.** Likely a *different* env var setup at runtime than the one you tested with — check the user's process actually receives `HH_API_KEY` (e.g., docker-compose `env_file:`, k8s `envFrom:`, systemd `EnvironmentFile`). The validation curl ran in the user's shell; the app may run in a different env.
+- **403 on a key that "used to work."** Either the key was rotated and the old one is revoked, or the user's API-key role was downgraded.
+- **Connection error from inside a container/k8s pod but not from the user's laptop.** Egress policy blocks outbound `:443` to the HoneyHive host. Surface the URL + port to the user's network team; the skill can't fix this.
+

--- a/.agents/skills/honeyhive-evaluate/SKILL.md
+++ b/.agents/skills/honeyhive-evaluate/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: honeyhive-evaluate
+description: >
+  Set up and verify HoneyHive experiments for an AI agent or LLM workflow. Use
+  when the user wants to evaluate an agent, run an experiment, create or reuse a
+  dataset, add evaluators or rubrics, compare experiment runs, or wire
+  `evaluate()` with HoneyHive. Triggers on phrases like "evaluate my agent",
+  "run an experiment", "create an eval dataset", "add evaluators", "compare
+  runs", `honeyhive experiments`, `honeyhive datasets`, or `evaluate()`.
+license: MIT
+metadata:
+  version: "0.1.0"
+  homepage: https://docs.honeyhive.ai
+---
+
+# HoneyHive Evaluate
+
+Set up the smallest useful HoneyHive experiment for the user's AI workflow: identify the target, shape or reuse a dataset, choose a compact evaluator set, run the experiment, and verify the results can be compared.
+
+For relevant v2 documentation links, see [references/v2-docs.md](references/v2-docs.md).
+
+## Phase 0 - Ask Before Acting
+
+Before changing code, dependencies, datasets, datapoints, experiment runs, or evaluators, understand the user's goal and get alignment. Prefer asking at most 2-4 targeted questions at once.
+
+Clarify:
+
+- **Target:** Which agent, function, route, notebook, or job should be evaluated? In a monorepo, identify the exact subtree before proceeding.
+- **Evaluation goal:** What regression or quality question should the experiment answer (accuracy, groundedness, tool-use success, safety, latency, cost, formatting, etc.)?
+- **Mode:** Is this an offline batch experiment, online production evaluation, or a comparison between two existing runs?
+- **HoneyHive state:** Does the user have `HH_API_KEY` set? Do they need a deployment URL set for a dedicated or self-hosted deployment (`HH_DATA_PLANE_URL` for TS/CLI users, `HH_API_URL` for Python)? Only ask about an explicit project override if the user wants a non-default project target or label.
+- **Resources:** Should the skill reuse existing datasets/evaluators/runs, or is it allowed to create new ones?
+- **Edit tolerance:** Is the user okay with code changes, dependency changes, and local commands, or do they only want a plan?
+
+If the target workflow or permission to mutate resources is ambiguous, stop and ask. Do not guess.
+
+## Phase 1 - Read-Only Discovery
+
+Run discovery before proposing any changes.
+
+1. **Find the target workflow.** Search for agent entry points, LLM calls, RAG pipelines, tool loops, eval scripts, notebooks, routes, and tests. Scope all future edits to that subtree.
+2. **Detect existing evaluation work.** Look for `evaluate(`, `run_experiment(`, `experiments/`, eval-oriented tests, rubric docs, golden datasets, CSV/JSON test cases, HoneyHive dataset IDs, run IDs, CI regression scripts, or manual review workflows.
+3. **Inventory candidate data.** Identify existing examples from tests, logs, fixtures, user-provided files, HoneyHive datasets, or previous experiment runs.
+
+Discovery is read-only. Codebase inspection and read-only HoneyHive CLI commands are both allowed here. It is fine to use `honeyhive --help`, `honeyhive <namespace> --help`, and non-mutating list/get commands during discovery. Do not create, update, or delete datasets, datapoints, metrics/evaluators, or experiment runs yet.
+
+If the user is unsure what to measure, start from a small representative sample of examples and identify concrete failure modes before proposing evaluators. Review the full workflow when possible, not just the final output: user input, retrieved context or tool results, intermediate steps, and final output. Write observations, not theories, for example "missed the budget constraint" instead of "model was confused."
+
+## Phase 2 - Choose the Path
+
+Pick the smallest path that answers the user's evaluation question.
+
+- **Not instrumented yet:** You can still propose an offline experiment around the intended target workflow and a dataset, even if the agent is only partially built. Explain that trace-rich debugging and production-event datasets may require `honeyhive-instrument` first. Do not force instrumentation unless the user agrees.
+- **Already instrumented:** Reuse the existing tracing/session/event conventions. Do not add duplicate tracer or client setup.
+- **Existing HoneyHive dataset:** Verify it with `honeyhive datasets list` and inspect datapoints with `honeyhive datapoints list` / `get` where useful. Reuse it if the shape matches the target function.
+- **No dataset:** Propose a tiny seed dataset from existing examples, fixtures, logs, traces, or user-provided cases. Keep the first dataset small enough to review.
+- **Evaluation-first, partially built workflow:** Define the intended behavior and success criteria first, then create a seed dataset that describes that target behavior. Do not assume traces or production events already exist.
+- **Python target:** Use the Python SDK's experiment APIs (for example `evaluate()`) inside the user's evaluation harness. Use the HoneyHive CLI for HoneyHive resource CRUD and verification.
+- **TypeScript or non-Python target:** Prefer the HoneyHive CLI for terminal or agent-driven HoneyHive resource workflows when it exposes the needed operation. The TypeScript SDK (`@honeyhive/api-client`) and generated OpenAPI clients are also valid documented options for non-Python codebases. Build the smallest local harness that calls the target workflow and records or links results. Do not pretend Python-only helpers exist in TypeScript.
+- **CLI availability:** If `honeyhive` is not installed, ask the user to install via `brew tap honeyhiveai/tap && brew install honeyhive`, or fall back to a non-CLI path.
+
+## Phase 3 - Plan and Wait
+
+Before mutating anything, present a concise plan and wait for the user's approval.
+
+The plan should include:
+
+- Target function or workflow and the repo subtree to edit.
+- Dataset source and shape, including whether it reuses an existing HoneyHive dataset.
+- Evaluator approach, including any metrics/evaluators to create or reuse.
+- Files to edit and dependencies, if any.
+- HoneyHive CLI commands that will create, update, or verify resources.
+- Validation steps and what success looks like.
+
+If the user rejects the plan or asks for a narrower scope, revise the plan before acting.
+
+## Phase 4 - Apply the Minimal Harness
+
+Use the HoneyHive CLI for API operations. Discover exact commands via `honeyhive --help` before use — see [honeyhive-cli](../honeyhive-cli/SKILL.md).
+
+Use SDK calls when they belong inside the user's code path or when the CLI does not expose the needed operation. For Python experiments, `evaluate()` is the preferred in-code orchestration API when it fits the target.
+
+Keep the first implementation small:
+
+1. Create or reuse one dataset.
+2. Add a small, reviewable set of datapoints.
+3. Add or reuse a compact evaluator set.
+4. Wire the target workflow into the experiment harness.
+5. Run the experiment only after the user has approved local command execution.
+
+Evaluator guidance:
+
+- Start with one or two high-impact evaluators, not a long list.
+- Prefer narrow checks over holistic scores. "did the answer match ground truth?" is better than "was this response good overall?"
+- Use code checks before LLM judges for objective criteria like schema conformance, exact-format checks, required fields, simple thresholds, or deterministic business rules.
+- Prefer binary pass/fail decisions over 1-5 or letter grades when possible. They are easier to calibrate and compare across runs.
+
+## Phase 5 - Validate
+
+Validation must prove the experiment can be used for regression tracking, not just that a script ran.
+
+Check:
+
+1. **Resource visibility:** The dataset is visible in the datasets namespace, and datapoints are linked as expected.
+2. **Run status:** The run is visible in the experiments namespace with a terminal or understandable status.
+3. **Metrics/results:** Experiment results or evaluator output are retrievable through the experiments namespace when metrics are expected.
+4. **Comparison:** If there is a baseline run, an experiments comparison command works programmatically.
+5. **Local fit:** The harness calls the intended target workflow and does not require unrelated refactors.
+
+If validation fails because the app is not instrumented, the dataset shape is wrong, the SDK version is incompatible, or some other user-side issue, stop with a clear explanation and the next recommended step.
+
+**Doc-gap protocol.** If validation fails due to missing CLI coverage or incomplete docs, follow the [doc-gap filing procedure](../honeyhive-cli/SKILL.md#doc-gap-filing).
+
+## CLI
+
+For CLI install, discovery, and schema introspection, see [honeyhive-cli](../honeyhive-cli/SKILL.md).
+
+## HoneyHive UI URL patterns
+
+When linking to HoneyHive resources in output or documentation, use these URL patterns. The base is `https://app.us.honeyhive.ai` (or the customer's dedicated app host). `{project_id}` is the project's scope ID (available via `honeyhive experiments get-run` → `.evaluation.scope_id`).
+
+| Resource | URL pattern |
+|----------|-------------|
+| Experiment run | `https://app.us.honeyhive.ai/p/{project_id}/experiments/runs/{run_id}` |
+| Dataset | `https://app.us.honeyhive.ai/p/{project_id}/datasets/{dataset_id}` |
+| Session | `https://app.us.honeyhive.ai/p/{project_id}/traces/sessions?event={session_id}` |
+
+## Gotchas
+
+- **Prefer the CLI for terminal or agent-driven resource workflows.** Use the SDK inside the user's harness when it belongs there, but prefer `honeyhive` for datasets, datapoints, experiment runs, and metrics/evaluators whenever the needed command exists.
+- **Evaluators may be called metrics.** Product language says "evaluators"; API and CLI surfaces may still say `metrics`. Bridge the naming for the user.
+- **No metric sprawl.** Too many small metrics make an event hard to understand. Prefer a compact set.
+- **No hidden resource creation.** Do not create datasets, datapoints, metrics, runs, or alerts until the user approves the plan.
+- **No secret writes.** Read `HH_API_KEY` and any relevant environment settings such as the deployment URL (`HH_DATA_PLANE_URL` for TS/CLI, `HH_API_URL` for Python) from the environment or ask the user to set them. Only ask for an explicit project override when the user needs one. Never write API keys to source files.
+- **No forced instrumentation.** If the app is not instrumented, explain the tradeoff and offer an offline path or a handoff to `honeyhive-instrument`.
+- **No version upgrades by default.** If the installed SDK or CLI is incompatible, surface the issue and ask before upgrading.

--- a/.agents/skills/honeyhive-evaluate/references/v2-docs.md
+++ b/.agents/skills/honeyhive-evaluate/references/v2-docs.md
@@ -1,0 +1,11 @@
+# Relevant v2 Docs
+
+When you need product or API documentation, prefer these v2 docs:
+
+- [Experiments Quickstart](https://docs.honeyhive.ai/v2/introduction/experiments-quickstart.md) for the smallest end-to-end experiment setup
+- [Evaluation Introduction](https://docs.honeyhive.ai/v2/evaluation/introduction.md) for the experiments mental model
+- [Comparing Experiments](https://docs.honeyhive.ai/v2/evaluation/comparing_evals.md) for regression and baseline workflows
+- [Experiments via API](https://docs.honeyhive.ai/v2/evaluation/via-api.md) for non-Python or custom orchestration paths
+- [Datasets Introduction](https://docs.honeyhive.ai/v2/datasets/introduction.md) and [Curate from Traces](https://docs.honeyhive.ai/v2/datasets/dataset-curation.md) for dataset reuse and creation
+- [Evaluators Introduction](https://docs.honeyhive.ai/v2/evaluators/introduction.md), [Python Evaluators](https://docs.honeyhive.ai/v2/evaluators/python.md), [LLM Evaluators](https://docs.honeyhive.ai/v2/evaluators/llm.md), and [Evaluator Template List](https://docs.honeyhive.ai/v2/evaluators/evaluator-templates.md) for evaluator design
+- [HoneyHive CLI](https://docs.honeyhive.ai/v2/cli-reference/getting-started.md), [SDK Overview](https://docs.honeyhive.ai/v2/sdk-reference/overview.md), [Python SDK](https://docs.honeyhive.ai/v2/sdk-reference/python-sdk-ref.md), and [TypeScript SDK](https://docs.honeyhive.ai/v2/sdk-reference/typescript-sdk-ref.md) for concrete v2 SDK and CLI surfaces

--- a/.agents/skills/honeyhive-improve/SKILL.md
+++ b/.agents/skills/honeyhive-improve/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: honeyhive-improve
+description: >
+  Debug and improve an AI agent or LLM workflow using HoneyHive trace data.
+  Use when the user has a failing session, event, evaluator, experiment run,
+  alert, or vague production complaint and wants root-cause analysis, a minimal
+  fix plan, or a verified improvement loop. Triggers on phrases like "debug this
+  trace", "investigate a failing session", "why did this run fail", "root cause",
+  "production issue", `honeyhive events search`, `honeyhive experiments`, or
+  evaluator failure analysis.
+license: MIT
+metadata:
+  version: "0.1.0"
+  homepage: https://docs.honeyhive.ai
+  feedback_url: https://github.com/honeyhiveai/skills/issues
+---
+
+# HoneyHive Improve
+
+Debug the failing part of the user's AI workflow with evidence first. Start from HoneyHive data when it exists, ask before mutating anything, propose the smallest evidence-backed fix, validate it, and stop.
+
+## Phase 0 - Ask Before Acting
+
+Before changing code, prompts, dependencies, evaluators, datasets, experiment runs, or HoneyHive resources, understand the failure and get alignment.
+
+If the host provides an ask-user-question or structured-question tool, use it for the few questions that determine the path. Prefer asking at most 2-4 targeted questions at once.
+
+Clarify:
+
+- **Failure target:** Does the user have a `session_id`, `event_id`, `run_id`, alert, evaluator failure, or only a vague complaint?
+- **Mode:** Is this an offline improvement loop or a production or online issue?
+- **Instrumentation state:** Is the app already instrumented in HoneyHive?
+- **Edit tolerance:** Does the user want read-only RCA, a plan only, or approval for minimal code or resource changes after review?
+
+If the failure target, repo subtree, or permission to mutate is unclear, stop and ask. Do not guess.
+
+## Phase 1 - Read-Only Discovery
+
+Run discovery before proposing changes.
+
+1. **Find the exact workflow.** Identify the agent, service, route, job, notebook, script, or repo subtree involved. In a monorepo, scope all later work to the smallest relevant subtree.
+2. **Detect HoneyHive versions and state.** Check manifests, lockfiles, and installed tooling for the HoneyHive SDK, CLI, tracer or instrumentor versions, plus any relevant framework version that could affect the failure mode. Also detect existing tracing setup, evaluators, prior experiment runs, datasets, and any alerting or regression workflow already in place.
+3. **Check the CLI surface before relying on it.** Use `honeyhive --help` and namespace help before using commands. Prefer the CLI for HoneyHive resource operations whenever the needed command exists.
+4. **Gather the smallest useful evidence set.** Start from one concrete failing example when possible: a failing session, event, run, evaluator result, user complaint tied to a time window, or one bad output from tests or logs.
+5. **Keep discovery read-only.** Do not edit code. Do not create or modify datasets, datapoints, metrics/evaluators, runs, or alerts yet.
+
+Discovery is read-only. Do not assume the app is already instrumented or that the user already has a fully built agent.
+
+## Phase 2 - Choose the Path
+
+Pick the smallest path that answers the user's immediate debugging question.
+
+- **Instrumented + concrete failing resource:** If the user has a `session_id`, `event_id`, or `run_id`, inspect that exact failure first. Reconstruct the failure from HoneyHive data before proposing a fix.
+- **Instrumented + vague complaint:** Narrow the complaint by time window, feature, evaluator signal, or complaint class. Turn the vague complaint into one concrete failing example before proposing changes.
+- **Not instrumented yet:** Say clearly that trace-backed RCA is blocked. Offer the smallest next step:
+  - use `honeyhive-instrument` first if the user wants trace visibility, or
+  - run an offline improvement loop from tests, fixtures, logs, or user-provided examples if they want to improve behavior now.
+- **Existing experiment runs:** Reuse them. Inspect the run, its metrics, and any baseline comparison before creating new evaluation resources.
+- **No runs yet:** Keep the first pass focused on diagnosis and the smallest fix. Do not force a formal experiment setup just to debug one failure.
+- **Python workflow:** Reuse an existing Python evaluation harness if one already exists. Do not assume the user wants to introduce one.
+- **TypeScript or non-Python workflow:** Use HoneyHive CLI for HoneyHive resources and the repo's existing local harnesses, tests, or scripts for reproduction. Do not pretend Python-only helpers exist.
+- **Offline issue:** Work from known failing examples, datapoints, runs, or tests.
+- **Production or online issue:** Start read-only, use recent HoneyHive evidence, and keep the remediation path narrow before recommending broader changes.
+
+## Phase 3 - Reconstruct the Failure
+
+Use HoneyHive data first when it exists. Prefer the CLI when a command exists, then fall back to installed SDK or API usage only when needed.
+
+Typical namespaces to inspect:
+
+- `honeyhive events`
+- `honeyhive experiments`
+- `honeyhive metrics`
+- `honeyhive datasets`
+- `honeyhive datapoints`
+
+Common read-only starting points:
+
+- `honeyhive --help`
+- `honeyhive events --help`
+- `honeyhive experiments --help`
+- `honeyhive metrics --help`
+
+If the installed CLI exposes them, common read-only actions may include event search, run lookup, run listing, run comparison, and metric listing. Discover the exact subcommand names from the installed CLI help instead of assuming they exist from this skill text.
+
+When reconstructing the failure:
+
+1. Start from the exact failing resource if the user has one.
+2. Review the full workflow when possible, not just the final output: user input, retrieved context, tool results, model steps, evaluator output, and final response.
+3. Use session, event, and span metadata to identify the failing step when possible.
+4. Find the first plausible failure point, not every downstream symptom.
+5. Write observations before explanations. Prefer "tool call returned no documents before the bad answer" over "the model was confused."
+6. Separate:
+   - **symptom** - what the user noticed
+   - **first plausible cause** - the earliest step that appears wrong
+   - **owner** - prompt, retrieval, tool call, model call, parser, evaluator, or infrastructure boundary
+
+Consult version-matched framework docs or changelogs only when the observed failure points there. Do not let broad framework research distract from trace-backed RCA.
+
+If the user only has a vague complaint and there are many candidate traces, narrow to a small review set first.
+
+## Phase 4 - Plan and Wait
+
+Before mutating anything, present a concise plan and wait for user approval.
+
+The plan should include:
+
+- the failure target and the HoneyHive evidence reviewed
+- the most likely root cause
+- the repo subtree to inspect or edit
+- whether any HoneyHive resource changes are proposed
+- whether any local reproduction, experiment rerun, or comparison is proposed
+- how validation will work
+
+If the user asked for read-only RCA only, stop after presenting findings and next-step options. Do not proceed into edits or resource creation.
+
+## Phase 5 - Apply the Minimal Fix
+
+Only after approval, apply the smallest change that matches the evidence.
+
+Good first-pass fixes:
+
+- a prompt or instruction update
+- a retrieval or query adjustment
+- a tool invocation or argument fix
+- a parser or schema guard
+- an evaluator correction
+- a small config or wiring change
+
+Avoid:
+
+- unrelated refactors
+- framework upgrades by default
+- broad rewrites
+- hidden HoneyHive resource creation
+
+Use the HoneyHive CLI for HoneyHive resource operations whenever the command exists. Use SDK or API calls only when the CLI does not expose the needed operation or when the change belongs inside the user's code path.
+
+## Phase 6 - Validate and Stop
+
+Validation should prove the failure no longer reproduces in the smallest reasonable loop.
+
+Choose the lightest validation that fits the problem:
+
+1. confirm the local behavior now matches the intended path
+2. confirm the failing case no longer reproduces
+3. confirm the bad pattern is no longer visible in HoneyHive, if new trace data is available
+4. if the user wants regression tracking, hand off to `honeyhive-evaluate` to reuse or create the smallest useful experiment and compare against the failing baseline
+
+After the minimal fix is validated, stop. Do not expand scope into broader instrumentation, evaluation, or refactors unless the user asks.
+
+## Inline Investigation Summary
+
+Use this output shape when it helps:
+
+```text
+Investigation Summary
+- Failure target:
+- Evidence reviewed:
+- First plausible failure point:
+- Owner:
+- Recommended minimal fix:
+- Validation plan:
+- Open uncertainty:
+```
+
+## HoneyHive UI URL patterns
+
+When linking to HoneyHive resources in output or documentation, use these URL patterns. The base is `https://app.us.honeyhive.ai` (or the customer's dedicated app host). `{project_id}` is the project's scope ID (available via `honeyhive experiments get-run` → `.evaluation.scope_id`).
+
+| Resource | URL pattern |
+|----------|-------------|
+| Experiment run | `https://app.us.honeyhive.ai/p/{project_id}/experiments/runs/{run_id}` |
+| Dataset | `https://app.us.honeyhive.ai/p/{project_id}/datasets/{dataset_id}` |
+| Session | `https://app.us.honeyhive.ai/p/{project_id}/traces/sessions?event={session_id}` |
+
+## Gotchas
+
+- **No trace-backed claims without traces.** If the app is not instrumented, say so and switch to an offline path or recommend `honeyhive-instrument`.
+- **CLI-first for HoneyHive resources.** Use the CLI whenever it exposes the needed command. Do not hardcode undocumented commands from memory.
+- **No hidden mutations.** Do not edit code or create or update datasets, datapoints, metrics/evaluators, runs, or alerts until the user approves the plan.
+- **Do not chase every symptom.** Focus on the first plausible failure point.
+- **Do not overfit to framework lore.** Consult version-matched framework docs or changelogs only when the observed failure points there.
+- **Do not overbuild the fix.** Prefer one narrow improvement over a broad rewrite.
+- **Do not force formal eval setup.** If no experiment workflow exists yet, offer `honeyhive-evaluate` as a follow-up instead of making it a prerequisite for every debug task.
+
+## Doc Gap Protocol
+
+If the CLI, installed HoneyHive version, framework integration, or trace-analysis path needed for the investigation is not covered well enough for a reliable next step, do not improvise a broad recipe. Tell the user what is missing, what you were able to verify, and suggest opening an issue at the public skills repo issue tracker (`metadata.feedback_url`) with the HoneyHive CLI or SDK version, framework, and scenario.

--- a/.agents/skills/honeyhive-instrument/SKILL.md
+++ b/.agents/skills/honeyhive-instrument/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: honeyhive-instrument
+description: >
+  Instrument an AI application with HoneyHive tracing. Use when the user wants
+  to add observability, capture traces, set up the SDK, configure exporters,
+  or wire OpenTelemetry-compatible instrumentation for an agent, RAG pipeline,
+  or LLM application. Triggers on phrases like "add tracing", "instrument my
+  app", "wire up HoneyHive", "set up the SDK", "capture spans", "OTEL
+  exporter", or any mention of `HoneyHiveTracer.init`, `@honeyhive/api-client`,
+  `client.sessions.startSession`, `client.events.createEvent`, or
+  `OpenInference`/`Traceloop` instrumentors targeting HoneyHive.
+license: MIT
+metadata:
+  version: "0.2.0"
+  homepage: https://docs.honeyhive.ai
+  feedback_url: https://github.com/honeyhiveai/skills/issues
+---
+
+# HoneyHive Instrument
+
+Wire HoneyHive tracing into a user's application with a small, surgical edit set: initialize the tracer, attach an instrumentor for their LLM/agent framework, and verify spans flush.
+
+> **You are an instrumentation surgeon, not a rewriter.** The user has working code. Add tracing in the smallest number of edits possible. Never refactor unrelated code, never change framework versions, never strip features.
+
+## Three phases only
+
+This skill has exactly three phases. Each phase has a **checkpoint** — a concrete artifact that proves the phase ran. If you skip a phase, the checkpoint will be missing and the eval will catch it.
+
+| Phase | Goal | Checkpoint |
+|-------|------|------------|
+| **Validate** | Confirm network + runtime before touching code | Curl returns HTTP 200 + runtime findings recorded |
+| **Setup** | Add tracing wiring via the language-specific reference | Exactly one setup reference loaded + edits applied |
+| **Verify** | Smoke run + grade against success.md | Session visible in HoneyHive + success.md loaded and graded |
+
+## Phase 1 — Validate (deterministic, no user questions until stuck)
+
+Validation is deterministic discovery. Run checks in order; stop on failure. Only ask the user when a check is ambiguous.
+
+### Step 1.1 — Network validation
+
+Load and follow [references/network-validation.md](../honeyhive-cli/references/network-validation.md).
+
+Run the reachability check:
+
+```bash
+curl -sS -o /dev/null -w "HTTP %{http_code}\n" \
+  -H "Authorization: Bearer $HH_API_KEY" \
+  "${HH_DATA_PLANE_URL:-$HH_API_URL}/healthcheck"
+```
+
+**Checkpoint:** Curl returns HTTP 200. If not, stop with the exact error from the interpretation table below. Do not retry. Do not proceed.
+
+| HTTP code | Cause | Recovery |
+|-----------|-------|----------|
+| 200 | Valid | Proceed |
+| 401 | Key invalid for this deployment | Redirect user to project settings: https://app.us.honeyhive.ai/settings/project/keys |
+| 403 | Key lacks project scope | Redirect user to project settings: https://app.us.honeyhive.ai/settings/project/keys |
+| 404 | Wrong URL | Verify the deployment URL (`HH_DATA_PLANE_URL` for TS/CLI, `HH_API_URL` for Python), no trailing slash |
+| 000 | Egress blocked | Surface URL + port to network team |
+
+### Step 1.2 — Runtime validation
+
+Load and follow [references/runtime-validation.md](references/runtime-validation.md).
+
+This is a read-only scan. Do not edit any files. Detect:
+
+1. **Subtree** — locate the LLM app in a monorepo (ask if ambiguous)
+2. **Language + runtime** — from manifests (pyproject.toml, package.json, go.mod, etc.)
+3. **Framework + version** — which LLM SDK is pinned
+4. **Instrumentor family** — OpenInference vs Traceloop (Python only)
+5. **Existing HH wiring** — grep for `HoneyHiveTracer.init` / `new Client(`
+6. **Existing OTel provider** — grep for `TracerProvider` setups from other vendors
+
+**Checkpoint:** All six findings recorded. The setup path (Python / TypeScript / native OTel) is determined.
+
+### Step 1.3 — Confirm the path with the user
+
+Present findings and the proposed setup path. Confirm before adding dependencies.
+
+## Phase 2 — Setup (load exactly one language reference; follow it end-to-end)
+
+Pick the path that matches runtime-validation findings. Load **exactly one** setup reference:
+
+- **Python** — [references/python-setup.md](references/python-setup.md)
+- **TypeScript** — [references/ts-setup.md](references/ts-setup.md)
+- **Native OTel** (Go, Rust, Java, .NET, any bespoke OTel) — [references/otel-setup.md](references/otel-setup.md)
+
+Each setup file consumes Phase 1's findings and has its own internal steps (dependency plan, init placement, session boundaries, distributed propagation, verification). Follow it end-to-end.
+
+**Load additional references only when findings demand it:**
+- `existing_otel_provider = real:<vendor>` → also load [references/co-existence.md](references/co-existence.md)
+- `deployment_type = dedicated | self-host` → also load [references/dedicated-deployments.md](../honeyhive-cli/references/dedicated-deployments.md)
+
+For frameworks with first-class docs coverage, also pull the framework's integration docs page for the exact install + minimal-integration block — copy verbatim, adapt to the user's entry-point:
+
+- **Integrations index** — <https://docs.honeyhive.ai/v2/integrations> (find the user's framework here)
+- **Tracing quickstart** — <https://docs.honeyhive.ai/v2/introduction/tracing-quickstart>
+- **SDK reference** — <https://docs.honeyhive.ai/v2/sdk-reference> (Python, TypeScript, semconv)
+
+**Checkpoint:** Setup reference loaded. Dependency changes proposed (not yet committed). Init placement, session boundaries, and propagation strategy decided.
+
+If the user's framework isn't on the index above, follow the doc-gap protocol in Phase 3 step 3.
+
+## Phase 3 — Verify
+
+### Step 3.1 — Smoke run
+
+Run the user's main entry-point with a one-line dummy prompt (if env vars are set). Confirm:
+- Process exits 0
+- No OTEL warnings (`No tracer provider has been initialized`, `Span context lost`)
+
+### Step 3.2 — Mechanical trace check
+
+Query for events using the events search endpoint:
+
+```bash
+curl -s -X POST "${HH_DATA_PLANE_URL:-$HH_API_URL}/v1/events/search" \
+  -H "Authorization: Bearer $HH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"project": "<project-name>", "filters": [{"field": "event_type", "operator": "is", "value": "session", "type": "string"}], "limit": 5}'
+```
+
+Find the most recent session, then search for its child events:
+
+```bash
+curl -s -X POST "${HH_DATA_PLANE_URL:-$HH_API_URL}/v1/events/search" \
+  -H "Authorization: Bearer $HH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"project": "<project-name>", "filters": [{"field": "session_id", "operator": "is", "value": "<session-id>", "type": "string"}], "limit": 50}'
+```
+
+Verify: at least one event exists, and at least one has `event_type: "model"` (LLM span). If zero events or no model events, go back to Phase 2.
+
+### Step 3.3 — Grade against success criteria
+
+Load [success.md](success.md) and grade the trace:
+
+- **Trace structure** — are event names meaningful? are model events shallow (depth ≤ 2)? are tool calls linked to parent agent?
+- **Input/output cleanliness** — does the session show the user's query? do LLM events show full message history + tools + response?
+- **Semantic failures** — are errored events surfaced clearly, not buried in metadata?
+- **Summarisability** — is there a final event with enough context for end-to-end evaluators?
+
+If the trace is mechanically correct but qualitatively messy, circle back to Phase 2 and adjust session-boundary placement or instrumentor choice. **A mechanically-correct integration that produces a messy trace is not done.**
+
+> **Auto-instrumentation may not capture everything important.** If the trace is missing key steps (e.g., retrieval, tool calls, orchestration logic), add manual spans and enrichments using the APIs from the setup reference loaded in Phase 2. Auto-instrumentation is the starting point, not the ceiling.
+
+### Step 3.4 — Verify against MUSTs
+
+Review the code changes against the Requirements (MUSTs) section below. Confirm no violations (hardcoded keys, dual tracer, global provider hijack, etc.).
+
+### Step 3.5 — Doc-gap surfacing
+
+If during discovery you found a framework, instrumentor, or OTel exporter combination not covered above, do **not** improvise. Tell the user: "I've flagged this as a doc gap; here's the working install I produced; please open an issue at <https://github.com/honeyhiveai/skills/issues> if you'd like first-class coverage."
+
+**Checkpoint:** Session visible in HoneyHive with model events. success.md loaded and graded. Trace passes the rubric.
+
+## Stop
+
+Single-pass. Do not continue iterating after success criteria are met. Instrumentation is the only goal — once spans are flowing and the trace grades well, hand off to the user. Anything beyond (evaluating quality, improving prompts, tuning retrieval) is out of scope.
+
+## References
+
+Load only when the phase calls for them. Progressive disclosure keeps context tight.
+
+**Peer files:**
+
+- [success.md](success.md) — qualitative rubric for Phase 3 trace grading
+
+**Phase 1 — Validation:**
+
+- [references/network-validation.md](../honeyhive-cli/references/network-validation.md) — env var sourcing, curl reachability, status-code interpretation, TLS chain
+- [references/runtime-validation.md](references/runtime-validation.md) — subtree, language, framework, instrumentor, existing wiring, existing provider
+
+**Phase 2 — Setup (load exactly one):**
+
+- [references/python-setup.md](references/python-setup.md) — Python path
+- [references/ts-setup.md](references/ts-setup.md) — TypeScript path
+- [references/otel-setup.md](references/otel-setup.md) — Native OTel path (any language)
+
+**Operational (load when findings demand it):**
+
+- [references/co-existence.md](references/co-existence.md) — sharing a TracerProvider with a non-HH vendor
+- [references/dedicated-deployments.md](../honeyhive-cli/references/dedicated-deployments.md) — dedicated and self-host URL wiring
+- [references/prod-gotchas.md](references/prod-gotchas.md) — production checklist (deps, threading, memory, certs, PII, sampling)
+
+## Requirements (MUSTs)
+
+These are hard rules. Violating any one is a skill failure that evaluators will catch.
+
+- **MUST NOT proceed past Phase 1 without successful network validation.** Wrong URL or rejected key means every later step rebuilds sand.
+- **MUST NOT globally register HoneyHive as the source-of-truth TracerProvider.** The SDK doesn't do this; instrumentation code must not either. Evaluator: `no-global-provider-hijack`.
+- **MUST NOT construct two tracers (Python) or two Client instances (TS).** Reuse the existing instance. Evaluator: `no-dual-tracer-instances`.
+- **MUST NOT hardcode API keys.** Always sourced from env vars. Evaluator: `no-hardcoded-api-keys`.
+- **MUST NOT let the deployment URL silently fall back to the wrong host.** Confirm explicitly — the env var name varies by SDK (`HH_DATA_PLANE_URL` for TS/CLI, `HH_API_URL` for Python). Multi-tenant default is `https://api.dp1.us.honeyhive.ai`; dedicated and self-host customers have their own.
+- **MUST NOT switch instrumentor families** (OpenInference ↔ Traceloop) without explicit user consent.
+- **MUST NOT thread session_id through function signatures** (TS path). Use a module-level helper or async-context store.
+- **MUST NOT bump SDK or framework versions** to make instrumentation work.
+- **MUST NOT modify test files or lock files** unless the user explicitly asks.
+- **MUST NOT run a production deploy step.** Local smoke run is the verification ceiling.
+- **MUST load success.md at verification time** (Phase 3), not at the start.
+- **MUST record runtime-validation findings** before loading a setup reference. The setup file consumes findings, it does not re-detect.

--- a/.agents/skills/honeyhive-instrument/references/co-existence.md
+++ b/.agents/skills/honeyhive-instrument/references/co-existence.md
@@ -1,0 +1,45 @@
+# Coexisting with a non-HoneyHive `TracerProvider`
+
+`HoneyHiveTracer.init(...)` constructs an **independent** `TracerProvider` for HoneyHive — it does **not** call `trace.set_tracer_provider(...)` globally. The user's existing global provider (Datadog, New Relic, vendor-native) is untouched.
+
+**Import and initialization order rule:** In dual-provider scenarios, **always import and initialize the HoneyHive tracer provider after every other tracer provider.** This guarantees HoneyHive never accidentally becomes the global provider — even if a bug or misconfiguration causes a global registration, the user's primary vendor was already set as global first and won't be displaced.
+
+The real question with a pre-existing provider is **not** "will HoneyHive conflict?" — it's **"do you want the spans currently going to the user's other vendor to ALSO go to HoneyHive?"**
+
+## Decision tree
+
+### 0. Is the user's "existing provider" actually real?
+
+Before assuming coexistence is needed, check what `trace.get_tracer_provider()` (or the language equivalent) actually returns. The OTel API ships a *proxy* / *no-op* `TracerProvider` as the default — it returns spans that go nowhere. Many libraries import the OTel API without configuring a real SDK, so `get_tracer_provider()` returns this placeholder.
+
+Signals it's a no-op / placeholder:
+
+- The class name contains `Proxy`, `NoOp`, `Noop`, or `Default`.
+- No `SpanProcessor` is attached / no `add_span_processor` calls in the user's code.
+- No exporter is configured anywhere in the codebase.
+- The user can't name the backend their spans are going to.
+
+**If non-functional:** there's nothing to coexist with. `HoneyHiveTracer.init(...)` runs as if greenfield. Done.
+
+### 1. Real provider, no dual-export needed
+
+The simplest path: HoneyHive's tracer runs alongside the existing one, doing its own thing. New instrumentors you wire up for HoneyHive get `tracer_provider=tracer.provider` (the HoneyHive-private provider); existing auto-instrumentors that attach to the global keep flowing to the user's other vendor. **Two pipelines, no overlap, no shared state.** Pick this when the user only wants HoneyHive on the LLM/agent surface and is fine leaving their Datadog/New Relic pipeline alone for everything else.
+
+### 2. Real provider, dual-export wanted
+
+The user wants spans currently going to their other vendor to ALSO appear in HoneyHive — same auto-instrumentors, two backends. Two sub-cases:
+
+- **Provider exposes a way to add another span processor** (`add_span_processor` / `addSpanProcessor` / equivalent — most OTel SDK providers do): add a HoneyHive `BatchSpanProcessor` (with the OTLP exporter pointing at HoneyHive's collector) to the existing provider. Spans flow to both backends from the same provider. Do **not** call any global tracer-provider setter.
+- **Provider does not expose this** (some vendor-wrapped agent shims hide or lock the internal pipeline): the OTEL pipeline can't carry HoneyHive too. Fall back to the HoneyHive REST API directly — `POST /v1/sessions` to open a session, `POST /v1/events` per model call, `POST /v1/events/search` to query (see the [OpenAPI spec](https://github.com/honeyhiveai/honeyhive-openapi/blob/main/openapi.yaml) for the full v1 surface). The user's OTEL pipeline is left untouched for their other vendor; HoneyHive runs as a parallel, non-OTEL instrumentation. Surface this as a finding so the user knows why they're not getting auto-instrumented spans on the HoneyHive side.
+
+### 3. Refuse cases
+
+- **Existing provider has a custom `SpanProcessor` that mutates attributes.** Mutating processors will rewrite gen_ai/openinference attributes and the spans HoneyHive receives won't match dashboards. Refuse dual-export; ask the user which provider should be source-of-truth.
+- **User's policy forbids dual-export.** Don't wire HoneyHive into the existing pipeline; either run HoneyHive independently (decision tree §1) or skip.
+
+## Anti-patterns
+
+- **Don't wrap the user's provider in a `MultiplexingTracerProvider` that you wrote yourself.** OTEL spec doesn't define multiplexing semantics; downstream tools may treat it as a bug. Use one provider with two processors instead.
+- **Don't change the user's sampler.** If their existing provider uses `TraceIdRatioBased(0.1)`, adding HoneyHive's processor inherits that sampling. That's the correct behavior — do not "fix" it.
+- **Don't write code that globally registers HoneyHive as the source-of-truth provider** (`trace.set_tracer_provider(hh.provider)`). The SDK doesn't do this; the instrumentation layer shouldn't either.
+- **Don't import or initialize HoneyHive's tracer before the user's primary vendor.** Both import order and initialization order matter — always import and init HoneyHive last so it can never hijack the global provider, even accidentally.

--- a/.agents/skills/honeyhive-instrument/references/otel-setup.md
+++ b/.agents/skills/honeyhive-instrument/references/otel-setup.md
@@ -1,0 +1,152 @@
+# Native OTel setup (any language)
+
+For Go, Rust, Java, .NET, C++, or any app with a fully bespoke OpenTelemetry setup that the Python/TS HoneyHive SDKs cannot wrap. Same shape as Python setup in spirit — early init, session-boundary placement, span capture on key steps, distributed propagation — but every hook is built from the user's existing OTel SDK rather than from the HoneyHive SDK.
+
+Assumes [`network-validation.md`](../../honeyhive-cli/references/network-validation.md) has confirmed reachability and [`runtime-validation.md`](runtime-validation.md) has produced findings (`language`, `runtime_version`, `existing_otel_provider`). This file consumes those findings rather than re-detecting.
+
+> **This recipe lives here, not on docs.honeyhive.ai (yet).** Until the public integrations tab publishes a Native OTel page, this file is the source of truth for the OTLP attribute contract.
+
+## Reference docs
+
+- [Semantic-convention reference](https://docs.honeyhive.ai/v2/sdk-reference/semconv-reference)
+- [Framework attribute mapping](https://docs.honeyhive.ai/v2/sdk-reference/semconv-alignment)
+
+## TL;DR
+
+| | Value |
+|---|---|
+| **OTLP HTTP endpoint** | `https://api.dp1.us.honeyhive.ai/opentelemetry/v1/traces` (dedicated / self-host customers use their own per-tenant host — see [`dedicated-deployments.md`](../../honeyhive-cli/references/dedicated-deployments.md)) |
+| **Auth header** | `Authorization: Bearer <PROJECT API KEY>` — keys are scoped to a single project; no per-span project routing needed |
+| **Session correlation** | Set baggage attributes (`honeyhive.session_id`, optionally `honeyhive.session_name`) at the session boundary, OR run a small custom `SpanProcessor` that stamps them at export time |
+
+## Step 0 — Translate runtime-validation findings into a setup plan
+
+Inputs (from [`runtime-validation.md`](runtime-validation.md) output):
+
+- `language` (Go / Rust / Java / .NET / C++ / Python-going-via-OTel / TS-going-via-OTel)
+- `runtime_version`
+- `existing_otel_provider` — most relevant for this path; whether the user already has an OTel SDK provider configured for their other backend
+- `existing_otel_provider`'s sampler + processor list (if real)
+
+Decisions:
+
+| Finding | Action |
+|---|---|
+| `existing_otel_provider = none` or `proxy-noop` | Greenfield install: register a real `TracerProvider` with `BatchSpanProcessor` + OTLP exporter pointing at HoneyHive (Step 1). |
+| `existing_otel_provider = real:<vendor>` (Datadog/New Relic/etc.) | Do **not** replace it. Either add a HoneyHive `BatchSpanProcessor` to the existing provider for dual-export (most languages support `addSpanProcessor` on a live provider), or surface a refusal if it doesn't expose that hook (rare for native OTel SDKs; common for closed-source agent shims). See [`co-existence.md`](co-existence.md). |
+| `existing_otel_provider = real:custom-mutating` | **Refuse dual-export.** A mutating `SpanProcessor` will rewrite gen_ai/openinference attributes — surface to the user before proceeding. |
+| `existing_otel_provider`'s sampler is non-`AlwaysOn` (e.g. `TraceIdRatioBased(0.1)`) | Surface to the user — head-based sampling will silently drop most LLM sessions. Recommend `ParentBased(AlwaysOn)`. **Don't change the sampler unilaterally.** |
+
+OTel SDK packages the user already has installed determine which of the language column patterns in the rest of this file applies. Don't add extra OTel SDK packages unless the user genuinely lacks them — assume the runtime-validation findings tell you what's there.
+
+**Never bump OTel SDK versions** to make HoneyHive's exporter work. If `OTLPSpanExporter` types or processor interfaces have shifted across SDK versions, surface the version mismatch and let the user decide whether to upgrade.
+
+## Step 1 — Early initialization
+
+Initialize the user's OTel SDK at app startup, before any traced code runs. Register:
+
+- An OTLP HTTP exporter pointing at HoneyHive's collector with the `Authorization: Bearer <project key>` header.
+- A `BatchSpanProcessor` wrapping that exporter (almost always — synchronous exporters belong only in tests).
+- *Either* a small custom `SpanProcessor` that stamps `honeyhive.*` attributes (the [span-processor pattern](#span-processor-pattern) below), *or* nothing extra if you're going to set baggage at the session boundary instead (Step 2).
+
+Same constraint as Python and TS: this happens once at process startup. **Never inside a request handler**, never lazily — the OTel SDK gets unhappy if a real provider is set after a no-op default has been observed.
+
+## Step 2 — Locate the session boundary; set `honeyhive.session_id`
+
+The hardest part of native OTel is finding the right place in the user's code where a session **logically begins or resumes** and stamping the session id there. Same map as Python's `create_session` placement:
+
+| App shape | Where to stamp `honeyhive.session_id` |
+|---|---|
+| **HTTP service** | Per-request middleware that runs at handler entry |
+| **CLI / one-shot** | At the top of `main()` |
+| **Worker / consumer** | At the start of each unit of work (per message, per job, per polled batch) |
+| **Multi-service mid-session entry** | Wherever the request enters this service (continuation of a session that started elsewhere) |
+
+Two ways to actually attach the session id:
+
+### (a) Baggage (orthodox)
+
+Set `honeyhive.session_id` (and optionally `honeyhive.session_name`) as OTel baggage entries at the session boundary. Configure a baggage span processor (most OTel SDKs ship one as `BaggageSpanProcessor` or equivalent) so the baggage flows onto every span emitted within that context. This is the cleanest pattern for distributed apps because the baggage propagates across services automatically when W3C `baggage` headers are wired up.
+
+### (b) Custom span processor — the GUID shortcut <a name="span-processor-pattern"></a>
+
+If the user already has a request-id / correlation-id / conversation-id propagated end-to-end, **skip baggage entirely**. Run a small `SpanProcessor` whose `OnStart` (or `OnEnd`) reads that id off the span attributes and stamps it as `honeyhive.session_id` plus `honeyhive.session_auto_create=true`:
+
+```
+class HoneyHiveProcessor(joining_attribute_key):
+    def OnEnd(span):
+        joining_value = span.attributes.get(joining_attribute_key)
+        if joining_value is not None:
+            span.set_attribute("honeyhive.session_id", joining_value)
+        span.set_attribute("honeyhive.session_auto_create", true)
+```
+
+The processor takes one config knob — the joining attribute key (e.g. `"session.id"`, `"conversation.id"`, `"gen_ai.session.id"`, `"chat_id"`, or any custom name the app already emits). Same input → same id → all services in the chain end up with the same HoneyHive session without baggage / W3C-tracecontext setup.
+
+If the joining attribute is absent on a given span, only stamp `honeyhive.session_auto_create=true` — HoneyHive's resolution chain (`traceloop.association.properties.session_id` → `session.id`) takes over.
+
+| Language | `SpanProcessor` interface | Where to register |
+|---|---|---|
+| Go    | `sdktrace.SpanProcessor` (`OnStart`/`OnEnd`) | `sdktrace.WithSpanProcessor(...)` on the provider |
+| Java  | `io.opentelemetry.sdk.trace.SpanProcessor` | `SdkTracerProvider.builder().addSpanProcessor(...)` |
+| .NET  | `BaseProcessor<Activity>` | `OpenTelemetrySdk.CreateTracerProviderBuilder().AddProcessor(...)` |
+| Rust  | `opentelemetry_sdk::trace::SpanProcessor` | `TracerProvider::builder().with_span_processor(...)` |
+| Python | `opentelemetry.sdk.trace.SpanProcessor` | `TracerProvider.add_span_processor(...)` (only when Python is genuinely going through this native-OTel path; otherwise prefer [`python-setup.md`](python-setup.md)) |
+
+Register **before** the `BatchSpanProcessor` so attributes are stamped before the export queue serializes the span.
+
+> **Recommend (b) when the user has a propagated GUID; recommend (a) when they don't and a structural addition isn't worth it.** OTTL transforms in an OpenTelemetry Collector are a third option if the user's app exports through a collector — same logic, expressed in collector config; see <https://opentelemetry.io/docs/collector/transforming-telemetry/>.
+
+## Step 3 — Span capture on key processing steps
+
+Once the session boundary is stamped, the actual *spans* still have to be there. Native OTel doesn't auto-instrument LLM calls — wrap each meaningful step yourself:
+
+- LLM call → span with `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, plus `inputs`/`outputs` attributes for the message history and response.
+- Tool call → span with the tool name, `inputs`, `outputs`, and `event_type=tool` (or the OTel equivalent attribute).
+- Agent step / orchestration node → span wrapping the LLM + tool calls underneath, with the agent name in the span name.
+- Retrieval step → span with the query, retrieved doc ids, and ranking.
+
+These are what the [`success.md`](../success.md) rubric grades against — the trace will look mechanically correct without them but qualitatively empty.
+
+## Step 4 — Distributed trace context propagation (or sidestep it)
+
+When the app spans services, propagation matters:
+
+### Approach A — W3C tracecontext + baggage propagators
+
+Configure global propagators (`OTEL_PROPAGATORS=tracecontext,baggage` env var, or per-language equivalent). Every outbound HTTP / gRPC / message-bus client must inject; every inbound handler must extract. Async work that crosses thread / process boundaries (executors, queues) must propagate context manually.
+
+### Approach B — GUID shortcut (often simpler)
+
+If the user has a propagated correlation id already, the custom span processor in Step 2(b) reads it on every service in the chain. No baggage propagators, no W3C tracecontext setup, no debugging cross-`async_hooks` context loss. Same caveat as Python — needs an existing propagated GUID, but most modern services have one.
+
+## All `honeyhive.*` protocol attributes
+
+`honeyhive.*` attributes are *protocol* attributes — they control routing and grouping but are not stored as user-visible span attributes (they will not appear in the UI's span attribute list).
+
+| Attribute | Type | Required | Notes |
+|---|---|---|---|
+| `honeyhive.session_id` | string | required for span→session association | Highest-priority of the resolution chain. Falls back to `traceloop.association.properties.session_id` → `session.id`. |
+| `honeyhive.session_auto_create` | bool | required for auto-correlation | Tells HoneyHive to create a session automatically from the span's `session_id` and timestamps. Without it, a span with an unknown `session_id` is accepted (200 OK) but no session is created — spans appear orphaned in the UI. Safe to stamp on every span; duplicates are no-ops. |
+| `honeyhive.session_name` | string | optional | Defaults to `"Session"` on auto-create. Set this only when you want a specific human-readable name in the UI. |
+| `honeyhive.source` | string | optional | E.g. `"prod"`, `"dev"`, `"ci"`. Defaults to `"otlp"`. |
+| `honeyhive.experiment_metadata` | string (JSON) | optional | Used by the experiments runner to attach a span to a specific experiment run. |
+
+## Step 5 — Verify
+
+Before declaring success, confirm:
+
+- OTel SDK init runs once at app startup; the OTLP exporter targets the right HoneyHive host (multi-tenant default `api.dp1.us.honeyhive.ai`, or the dedicated/self-host URL per [`dedicated-deployments.md`](../../honeyhive-cli/references/dedicated-deployments.md)).
+- Authentication header uses the project API key from an env var (never a literal).
+- Session-boundary stamping is wired (Step 2) — either baggage at the boundary or a custom span processor reading a joining attribute.
+- Key processing steps are wrapped as spans with appropriate semconv attributes (Step 3).
+- For multi-service apps: either propagators are set up globally (Approach A) or every service's span processor is reading the same propagated GUID (Approach B).
+- Sampling: if the existing OTel setup uses head-based sampling (`TraceIdRatioBased(0.1)`), HoneyHive only receives that fraction of agent runs. For LLM workloads recommend `ParentBased(AlwaysOn)`. Don't change the user's sampler unilaterally; surface as a finding.
+- Run a smoke test. Inspect the resulting trace against [`success.md`](../success.md): is the trace structure easy to debug? Are session boundaries visible? Do LLM/tool/agent spans nest correctly?
+
+## Common failures
+
+- **Spans return 200 but never appear in the UI.** `honeyhive.session_id` resolved (directly or via the fallback chain) but `honeyhive.session_auto_create` is missing — HoneyHive has no signal to create a session from. Make sure the span processor is stamping `auto_create=true` on every span (or call `POST /session/start` separately).
+- **Each span shows up as its own session.** Different `session_id` values across spans the user expected to group together. Check the joining-attribute key — is it actually present and stable across the calls you expect to group? Log the joining value from inside the processor for one run to confirm.
+- **401 Unauthorized.** Missing `Bearer ` prefix, empty key env var, or the key was revoked. Use a project API key — the OTLP endpoint requires project scope.
+- **TLS errors against the deployment host.** Self-host certs may need a custom CA bundle; verify with `curl -v` before declaring success.

--- a/.agents/skills/honeyhive-instrument/references/prod-gotchas.md
+++ b/.agents/skills/honeyhive-instrument/references/prod-gotchas.md
@@ -1,0 +1,53 @@
+# Production gotchas (read before any prod-bound install)
+
+The customer docs ship the working install. This page is the failure-mode checklist — things that work in dev and silently break in prod. Surface each item to the user as a finding before they ship.
+
+## 1. Dependency conflicts
+
+- `opentelemetry-api` / `opentelemetry-sdk` version drift between the HoneyHive SDK and the user's existing pinning. Run `pip show opentelemetry-api opentelemetry-sdk` (or check `package.json`/`pnpm-lock.yaml`) before installing. If the user has `opentelemetry-api < 1.20`, surface the upgrade requirement; do not upgrade unilaterally.
+- `openinference-instrumentation-*` and `opentelemetry-instrumentation-*` for the same framework can both be installed; only one should be `.instrument()`-ed. If both run, attribute names diverge and dashboards split.
+- LangChain `>=1.x` vs `<1.x`: the OpenInference instrumentor for LangChain has different supported versions. Check the docs page for the version pin.
+
+## 2. Threading & async
+
+- **Background threads / executors do not inherit the OTEL context** unless propagated explicitly. If the user spawns work via `ThreadPoolExecutor`, `asyncio.to_thread`, `multiprocessing`, etc., either propagate the context manually (`opentelemetry.context.attach`) or wrap the entry-point with the `@trace()` decorator at the right boundary. **Common bug:** spans appear truncated because the LLM call ran in a worker thread that lost context.
+- In TypeScript, `async_hooks`/`AsyncLocalStorage` is the propagation mechanism. Ensure the OTEL SDK was imported at the very top of the entry-point (before any framework imports) so async-hooks is wired before user code runs.
+
+## 3. Distributed tracing
+
+- If the LLM app sits behind an API gateway or message queue, **trace context must propagate via headers** (`traceparent`, `tracestate`). Verify the gateway / queue isn't stripping them. For SQS/Kafka/Pub-Sub, you may need to attach the context to message attributes manually.
+- For multi-service architectures, set `OTEL_PROPAGATORS=tracecontext,baggage` in every service's environment.
+
+## 4. Memory caps
+
+- The default `BatchSpanProcessor` queue is 2048 spans. A high-throughput agent can overflow this in seconds, dropping spans silently. Surface to the user: increase `max_queue_size` and `max_export_batch_size` if their span rate is >100/s. (`OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`.)
+- Long-running processes that capture large `inputs`/`outputs` (full RAG documents, big tool I/O) accumulate per-span attribute payloads. Truncate aggressively or use the `enrich_span` pattern to capture only what's useful.
+
+## 5. Blocking calls
+
+- Do not put the OTLP exporter on a synchronous transport in latency-sensitive paths. The default `OTLPSpanExporter` is async; verify the user hasn't replaced it with a sync variant.
+
+## 6. Graceful exit
+
+The SDK handles span flushing on its own — you do **not** need to recommend an explicit `force_flush` / `flush` for normal long-running processes. The two exceptions:
+
+- **Lambda / Cloud Run / Cloud Functions:** the runtime will SIGKILL before the queue drains unless you explicitly flush at the end of the handler. Wrap each invocation in `try/finally` and call `tracer.force_flush(timeout_millis=2000)` (or `tracer.flush()` in TS) — this is the *only* place in the skill where an explicit flush is the right answer.
+- **Forking workers (gunicorn, uwsgi):** initialize the tracer **post-fork** in each worker. A pre-fork tracer leaks the parent's batch state into every child and produces session-id collisions.
+
+## 7. Network policy & certs
+
+- Self-hosted deployments may use a custom CA. If the user's runtime can't validate the cert, OTLP exports fail silently — the user sees no errors, just no spans appearing in the UI. Verify cert chain explicitly with `curl -v <deployment-url>/opentelemetry/v1/traces` (where `<deployment-url>` is `$HH_DATA_PLANE_URL` for TS/CLI users or `$HH_API_URL` for Python users) before declaring success.
+- Egress firewalls: the OTLP HTTP endpoint is `:443` outbound to the user's deployment host (default `api.dp1.us.honeyhive.ai`, or the customer's dedicated/self-host URL). If the user is behind a strict egress policy, surface the URL + port to their network team.
+- HTTP proxies: `HTTPS_PROXY` is honored by the default exporter, but `NO_PROXY` must include the HoneyHive domain when the proxy is corporate-only.
+
+## 8. PII & content
+
+- The OpenInference / Traceloop instrumentors capture **full message content by default**. For regulated workloads (PHI, PCI), set `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` (Traceloop) or use the OpenInference `record_inputs=False` flag. Surface this to the user as a finding before any prod-bound install if they handle regulated data.
+
+## 9. Sampling
+
+- `TraceIdRatioBased(0.1)` (10% sampling) at the head will silently drop 90% of agent runs. For LLM workloads we recommend `ParentBased(AlwaysOn)` because each session is independently valuable. Do not change the user's sampler unless they ask; surface as a finding.
+
+## 10. SDK version compatibility
+
+- Pin `honeyhive>=<X>,<<Y>` based on the framework's required range. The matrix is on the framework's docs page. If the user's `honeyhive` is below the minimum for their framework, surface the upgrade — do not upgrade unilaterally.

--- a/.agents/skills/honeyhive-instrument/references/python-setup.md
+++ b/.agents/skills/honeyhive-instrument/references/python-setup.md
@@ -1,0 +1,145 @@
+# Python setup
+
+For Python apps using `honeyhive` + a framework (OpenAI, Anthropic, LangChain, LlamaIndex, DSPy, CrewAI, AutoGen, Semantic Kernel, Strands, Bedrock, Google ADK, MCP, etc.).
+
+Assumes [`network-validation.md`](../../honeyhive-cli/references/network-validation.md) has confirmed reachability and [`runtime-validation.md`](runtime-validation.md) has produced findings (`framework`, `framework_version`, `instrumentor_family`, `existing_hh_wiring`, `existing_otel_provider`, etc.). This file consumes those findings rather than re-detecting.
+
+The skill's job in Python has five parts: **(0)** translate runtime-validation findings into a concrete dependency + instrumentor decision and install only what's missing; **(1)** decide whether the user's framework needs an external instrumentor or already emits OTel natively; **(2)** put `tracer.create_session(...)` (or `acreate_session(...)`) at the right place in the user's code; **(3)** handle distributed trace propagation when the app spans services — or sidestep it via the GUID shortcut; **(4)** verify everything against the framework + app shape.
+
+## Reference docs
+
+For Python frameworks first-class on docs, pull the framework's docs page for the exact install + minimal-integration block — copy verbatim, adapt to the user's entry-point, do not paraphrase.
+
+**Integration guides:**
+
+- [Tracing quickstart](https://docs.honeyhive.ai/v2/introduction/tracing-quickstart)
+- [OpenAI](https://docs.honeyhive.ai/v2/integrations/openai)
+- [Anthropic](https://docs.honeyhive.ai/v2/integrations/anthropic)
+- [Azure OpenAI](https://docs.honeyhive.ai/v2/integrations/azure_openai)
+- [AWS Bedrock](https://docs.honeyhive.ai/v2/integrations/aws_bedrock)
+- [Gemini](https://docs.honeyhive.ai/v2/integrations/gemini)
+- [LangChain](https://docs.honeyhive.ai/v2/integrations/langchain)
+- [LangGraph](https://docs.honeyhive.ai/v2/integrations/langgraph)
+- [LiteLLM](https://docs.honeyhive.ai/v2/integrations/litellm)
+- [DSPy](https://docs.honeyhive.ai/v2/integrations/dspy)
+- [CrewAI](https://docs.honeyhive.ai/v2/integrations/crewai)
+- [AutoGen](https://docs.honeyhive.ai/v2/integrations/autogen)
+- [OpenAI Agents SDK](https://docs.honeyhive.ai/v2/integrations/openai-agents)
+- [Claude Agent SDK](https://docs.honeyhive.ai/v2/integrations/claude-agent-sdk)
+- [Google ADK](https://docs.honeyhive.ai/v2/integrations/google-adk)
+- [Pydantic AI](https://docs.honeyhive.ai/v2/integrations/pydantic-ai)
+- [Semantic Kernel](https://docs.honeyhive.ai/v2/integrations/semantic-kernel)
+- [Strands Agents](https://docs.honeyhive.ai/v2/integrations/strands)
+
+**SDK + semantic conventions:**
+
+- [Python SDK](https://docs.honeyhive.ai/v2/sdk-reference/python-sdk-ref)
+- [Semantic-convention reference](https://docs.honeyhive.ai/v2/sdk-reference/semconv-reference)
+- [Framework attribute mapping](https://docs.honeyhive.ai/v2/sdk-reference/semconv-alignment)
+
+## Step 0 — Translate runtime-validation findings into a setup plan
+
+Inputs (from [`runtime-validation.md`](runtime-validation.md) output):
+
+- `framework`, `framework_version`
+- `instrumentor_family` ∈ {`openinference`, `traceloop`, `none`, `conflict`}
+- `existing_hh_wiring` (file:line, or `none`)
+- `existing_otel_provider` (`none` / `proxy-noop` / `real:<vendor>` / `real:custom-mutating`)
+
+Decisions:
+
+| Finding | Action |
+|---|---|
+| `instrumentor_family = conflict` | **Stop.** Both OpenInference and OpenLLMetry/Traceloop are pinned. Surface to the user; ask which family to keep. Never silently pick. |
+| `instrumentor_family = openinference` | Continue with OpenInference. If `openinference-instrumentation-<framework>` is missing for the detected framework, install it explicitly (`pip install openinference-instrumentation-<framework>`). Do not silently mutate a manifest the user did not commit. |
+| `instrumentor_family = traceloop` | Continue with OpenLLMetry/Traceloop. Same install rules. |
+| `instrumentor_family = none` | Default to OpenInference for new Python apps unless the framework is OTel-native (Step 1). |
+| `existing_hh_wiring != none` | **Reuse the existing tracer instance.** Skip the `HoneyHiveTracer.init(...)` step in Phase 1; the rest of setup augments the existing wiring (placing `create_session` calls, etc.). |
+| `existing_otel_provider = real:custom-mutating` | **Refuse dual-export.** A mutating SpanProcessor will rewrite gen_ai/openinference attributes — surface to the user before proceeding. See [`co-existence.md`](co-existence.md). |
+| `existing_otel_provider = real:<vendor>` (Datadog/New Relic) | Ask the user whether they want dual-export. If yes, follow [`co-existence.md`](co-existence.md) §2. If no, run HoneyHive's tracer independently (the SDK builds its own provider). |
+
+If `honeyhive` itself is missing from the manifest, install it explicitly: `pip install honeyhive`. Document the env vars (`HH_API_KEY`, `HH_API_URL`, `HH_PROJECT`) in the user's setup block so the install is reproducible.
+
+**Never bump the framework's version** to make instrumentation work. If the pinned version is incompatible with the chosen instrumentor, surface as a finding and let the user decide whether to upgrade.
+
+## Step 1 — OTel-native vs needs-an-instrumentor
+
+Not all Python LLM frameworks emit OpenTelemetry spans natively. The instrumentation strategy diverges:
+
+- **Framework already emits OTel spans**: just `HoneyHiveTracer.init(...)` is enough; the SDK's tracer provider picks them up via the OTel SDK. **Do not attach an external instrumentor on top of native spans** — you'll get duplicate or attribute-conflicting spans. Validate by running the user's app once with HoneyHive init only and confirming spans appear in the UI.
+- **Framework does not emit OTel spans**: attach the matching external instrumentor — `openinference-instrumentation-<framework>` (default) or `opentelemetry-instrumentation-<framework>` (if the user is already on OpenLLMetry). Pick the family already pinned in the user's deps; do not switch families.
+
+Some frameworks have *partial* native OTel support (e.g. only certain code paths emit spans). When in doubt, run the smoke test both ways (with and without the external instrumentor) and pick whichever produces the cleaner trace structure per [`success.md`](../success.md).
+
+## Step 2 — Place `tracer.create_session()` / `tracer.acreate_session()` correctly
+
+`HoneyHiveTracer.init()` configures the tracer once at process startup. **Sessions** are opened per logical unit of work via `tracer.create_session(...)` (sync) or `tracer.acreate_session(...)` (async). The session id lands in OpenTelemetry baggage so the span processor associates spans with the right session even across concurrent requests.
+
+The skill must locate the right place in the user's code to call create_session. The "right place" depends on the app shape:
+
+| App shape | Where to call `create_session` |
+|---|---|
+| **Web service** (FastAPI / Flask / Django / Starlette) | Middleware that runs per request — open the session at request entry, before any LLM call. The async variant (`acreate_session`) is required in async middleware. |
+| **CLI agent / one-shot script** | At the top of `main()`, or wherever the user-facing entry happens. One session per invocation. |
+| **Long-running worker** (Celery, RQ, SQS poller, Kafka consumer, custom loop) | At the start of each unit of work — per message, per job, per polled batch. **Never** at module load. |
+| **Streaming / chat session** | Whenever a new conversation starts (often on the first user message). Cache the session id in conversation state so subsequent messages can reuse it. |
+| **Notebook / interactive REPL** | Per cell or per logical experiment — the user picks. |
+
+**Anti-patterns to refuse:**
+
+- Calling `create_session` at module load (`tracer.create_session()` next to `HoneyHiveTracer.init(...)`) — this opens a single session for the whole process, defeating per-request isolation.
+- Calling `create_session` inside a tight loop where each iteration is *not* logically a new session.
+- Reusing a session id across unrelated requests in a multi-tenant process.
+
+### `inputs` / `metadata` at session start
+
+When you call `create_session`, populate the `inputs` arg with the user-facing query (or a representative payload) and `metadata` with anything that helps debugging — request path, user id, feature flags. This is what becomes the session's "head" event and what the [`success.md`](../success.md) "user's original query is easy to identify" rubric grades against.
+
+## Step 3 — Distributed trace context propagation
+
+When the user's LLM/agent flow spans multiple services (microservices, queue → worker handoffs, cross-process pipelines), spans from each service need to land in the **same** HoneyHive session. Two approaches:
+
+### (A) OTel context propagation (orthodox)
+
+- Inbound HTTP middleware extracts W3C `traceparent` + `baggage` headers, attaches them to the local OTel context.
+- Outbound HTTP clients inject the same headers.
+- HoneyHive's session id rides as a baggage attribute (`honeyhive.session_id`); the receiving service reads it with `skip_api_call=True` to attach to the existing session rather than creating a new one:
+
+  ```python
+  # Receiving service (mid-session entry):
+  inbound_session_id = baggage.get_baggage("honeyhive.session_id")
+  if inbound_session_id:
+      tracer.create_session(session_id=inbound_session_id, skip_api_call=True)
+  else:
+      tracer.create_session(...)  # this service is the session's origin
+  ```
+
+- Set up propagators globally: `opentelemetry.propagators.composite.CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])`.
+
+- Watch for context loss across `asyncio.to_thread`, `ThreadPoolExecutor`, `multiprocessing` — those don't auto-propagate. Either wrap the entry-point or manually `attach(context)` inside the worker.
+
+### (B) GUID shortcut (often simpler)
+
+If the user's app already has a request-id / correlation-id / conversation-id propagated end-to-end (X-Request-Id header, message envelope field, conversation_id in the payload), **skip baggage entirely**: each service derives the HoneyHive session_id from that GUID and calls `create_session(session_id=..., skip_api_call=True)` (after the first service, which makes the API call to actually create the session row).
+
+- If the GUID is already a UUID, pass it directly.
+- If it's not (numeric id, opaque external id), convert it deterministically: `str(uuid.uuid5(uuid.NAMESPACE_URL, raw_guid))`. Same input → same UUID → all services in the chain end up with the same session_id without any header propagation setup.
+
+This sidesteps the *whole* baggage / propagator / context-loss debugging surface. The tradeoff: the user must already have a propagated GUID (or be willing to add one to their request envelope). Most modern services do — request IDs are table stakes for debugging anyway.
+
+Recommend (B) when the user has a GUID; recommend (A) when they don't and a structural addition isn't worth it.
+
+## Step 4 — Verify
+
+Before declaring success, confirm:
+
+- `HoneyHiveTracer.init(...)` is called exactly once at process startup, with `api_key` + `project` from env vars (never literal). For dedicated/self-host, `server_url` set per [`dedicated-deployments.md`](../../honeyhive-cli/references/dedicated-deployments.md).
+- The chosen integration matches the framework's OTel story (Step 1):
+  - OTel-native framework → no external instrumentor attached.
+  - Non-OTel-native framework → exactly one instrumentor attached, family matches deps, `instrument(tracer_provider=tracer.provider)` called.
+- `tracer.create_session(...)` / `acreate_session(...)` lands at every session boundary — middleware for web, `main()` for CLI, per-message for workers. Inputs and metadata populated.
+- For multi-service apps: either propagators are set up globally (Approach A) or every service is calling `create_session(session_id=<derived from shared GUID>, skip_api_call=True)` (Approach B).
+- The SDK auto-flushes — do **not** add `tracer.force_flush()` as a general practice. The single exception is Lambda / serverless (see [`prod-gotchas.md`](prod-gotchas.md) §6).
+- Run the smoke test once with one real LLM call. Inspect the resulting trace against [`success.md`](../success.md): is the trace structure easy to debug? Are agent/tool/LLM events nested correctly? Is the user query identifiable?
+
+If the smoke trace is messy (deeply hidden LLM calls, wrong nesting, missing tool linkage), the integration is mechanically correct but qualitatively wrong — circle back and adjust the instrumentor choice or session-boundary placement.

--- a/.agents/skills/honeyhive-instrument/references/runtime-validation.md
+++ b/.agents/skills/honeyhive-instrument/references/runtime-validation.md
@@ -1,0 +1,121 @@
+# Runtime validation (Phase 0)
+
+Once [`network-validation.md`](../../honeyhive-cli/references/network-validation.md) confirms the user's credentials reach HoneyHive, the next step is to inspect the user's runtime: which language, which framework, what's already wired up, what existing tracing infrastructure exists. **Runtime validation feeds directly into Phase 1 setup** — the language-specific setup file consumes the structured findings produced here rather than re-detecting from scratch.
+
+## Step 0 — Identify the right sub-tree
+
+In a monorepo, the LLM/agent app may live in a subfolder (`packages/agent`, `services/rag`, `apps/chatbot`). Locate the entry-point file the user is referring to. If ambiguous, ask. **All subsequent reads in runtime validation, and all edits in Phase 1 setup, are scoped to this subtree.**
+
+Cheap way to scan for candidates:
+
+```bash
+# Files that import an LLM SDK — likely entry-points.
+rg -l 'openai|anthropic|langchain|llama_index|dspy|crewai|@anthropic-ai/sdk|honeyhive' \
+  --type-add 'web:*.{py,ts,tsx,js,mjs,go,rs,java,cs}' --type web \
+  | head -20
+```
+
+Confirm the scope with the user before proceeding.
+
+## Step 1 — Detect language + runtime
+
+Look at the manifest files in the chosen subtree to identify the language and runtime:
+
+| Language | Manifest signals |
+|---|---|
+| **Python** | `pyproject.toml`, `requirements.txt`, `uv.lock`, `Pipfile.lock`, `setup.py` |
+| **Node / Bun / Deno** | `package.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `deno.json` |
+| **Go** | `go.mod`, `go.sum` |
+| **Rust** | `Cargo.toml`, `Cargo.lock` |
+| **Java / JVM** | `pom.xml`, `build.gradle`, `build.gradle.kts` |
+| **.NET** | `*.csproj`, `*.fsproj`, `packages.lock.json` |
+
+The detected language determines which Phase 1 setup file to load:
+
+- Python → [`python-setup.md`](python-setup.md)
+- Node/Bun/Deno → [`ts-setup.md`](ts-setup.md)
+- Anything else → [`otel-setup.md`](otel-setup.md)
+
+Also note the **runtime version** (Python 3.x, Node 18 / 20 / 22, Go 1.x, etc.) — some downstream concerns (Lambda flush, async-context support) depend on it.
+
+## Step 2 — Detect framework + instrumentor family (Python especially)
+
+For each detected language, look at the dependency manifest to identify the LLM/agent framework and any pinned instrumentor:
+
+**Python — frameworks:**
+
+```bash
+# In the subtree's pyproject.toml / requirements.txt:
+rg '^(openai|anthropic|langchain|langgraph|llama-index|dspy|crewai|autogen|semantic-kernel|strands|openai-agents|anthropic-ai/claude-agent-sdk|google-adk|pydantic-ai|litellm)\b'
+```
+
+**Python — instrumentor family** (decisive for Path A vs Path B in setup):
+
+```bash
+rg '^openinference-instrumentation-' deps_files...    # OpenInference family
+rg '^opentelemetry-instrumentation-' deps_files...    # OpenLLMetry/Traceloop family
+```
+
+**Critical:** if both families are pinned, do **not** silently pick one — surface the conflict and ask. If exactly one is pinned, that's the family for setup; never switch.
+
+**TypeScript — frameworks:**
+
+```bash
+rg '"(openai|@anthropic-ai/sdk|@langchain/.+|@llamaindex/.+|crewai-js)"' package.json
+```
+
+There is no first-party TS auto-instrumentor today — TS uses `@honeyhive/api-client` for manual session/event construction.
+
+**Other languages:** look for `opentelemetry-*` or vendor-OTel SDKs (`go.opentelemetry.io/otel`, `Microsoft.OpenTelemetry`, etc.) — the language is going through Path C (native OTel) regardless of framework.
+
+## Step 3 — Check for pre-existing HoneyHive wiring
+
+Search the subtree for existing HoneyHive instantiations. **If a tracer / client already exists, never construct a second one.** Reuse the existing instance.
+
+```bash
+# Python:
+rg 'HoneyHiveTracer\.init\b|from honeyhive import' --type py
+
+# TypeScript / JS:
+rg 'new Client\b.*api-client|from .@honeyhive/api-client.|HoneyHiveTracer\.init\b' \
+  --type ts --type js
+```
+
+Findings to record:
+
+- **No wiring found** → Phase 1 setup creates the wiring fresh.
+- **Existing wiring found** → Phase 1 setup augments it (places `tracer.create_session` calls at session boundaries; doesn't re-init the tracer). Capture file:line so the setup file knows where to read from.
+- **Multiple `HoneyHiveTracer.init` / `new Client()` calls** — bug. Surface to the user; they need to consolidate before instrumentation can proceed cleanly.
+
+## Step 4 — Check for a pre-existing global OTel `TracerProvider`
+
+Look for code that has already configured a global OTel `TracerProvider` for a non-HoneyHive vendor (Datadog, New Relic, vendor-native). HoneyHive's tracer init is independent and won't hijack the global, so this isn't a refusal case — but it informs the dual-export decision in Phase 1.
+
+```bash
+# Python:
+rg 'trace\.set_tracer_provider\(|TracerProvider\(' --type py
+
+# TypeScript / JS:
+rg '(trace|api)\.setTracerProvider\(|new (Node|Web)TracerProvider\b' --type ts --type js
+
+# Go:
+rg 'otel\.SetTracerProvider\(|sdktrace\.NewTracerProvider\(' --type go
+```
+
+Findings to record:
+
+- **None / proxy-noop only** → no co-existence concern. (See [`co-existence.md`](co-existence.md) §0 for the proxy/no-op detection signals — class name contains `Proxy`/`NoOp`/`Default`, no SpanProcessor attached, no exporter configured.)
+- **Real provider, exporter pointing at Datadog/New Relic/etc.** → flag for Phase 1: ask the user whether they want dual-export. Decision tree in [`co-existence.md`](co-existence.md).
+- **Real provider with a custom mutating SpanProcessor** → flag for Phase 1 to refuse dual-export (mutating processors will rewrite gen_ai/openinference attributes).
+
+## Output — write `state/runtime-validation.json`
+
+Write all findings to `state/runtime-validation.json` (schema: [state-spec.md](state-spec.md)). Phase 1 setup files read this file and `state/network-validation.json` rather than re-running detection.
+
+The state file captures: `subtree`, `entrypoint` (the main execution entry-point file — Phase 1 uses this to place tracer init and session boundaries), `language`, `runtime_version`, `framework`, `framework_version`, `instrumentor_family`, `existing_hh_wiring` (array of `{file, line, type}`), `existing_otel_provider`, `existing_provider_ref`, `conflicts`, and `validated_at`. See [state-specs/runtime-validation.json](../state-specs/runtime-validation.json) for the full JSON Schema.
+
+Surface any conflicts (multiple instrumentor families, multiple existing tracers, custom-mutating provider) before any setup work begins.
+
+## When in doubt — ask, don't infer
+
+If any field above can't be determined with high confidence (the subtree has no manifest, the framework imports are dynamic, two instrumentor families are pinned, the existing-tracer call is wrapped in a factory function), surface the ambiguity to the user. Inferring a wrong framework or family produces a working-looking install that silently emits the wrong attribute set — exactly the kind of failure the validation phase exists to prevent.

--- a/.agents/skills/honeyhive-instrument/references/shareable-links.md
+++ b/.agents/skills/honeyhive-instrument/references/shareable-links.md
@@ -1,0 +1,86 @@
+# Shareable Links
+
+Generate shareable HoneyHive frontend URLs so the user can jump directly to a trace or experiment run in the UI.
+
+## Trace Link
+
+Opens a specific session or event in the traces view with the event drawer pre-opened.
+
+**Format:**
+```
+{base_url}/p/{projectId}/traces/{type}?event={eventId}&range={dateRange}
+```
+
+| Placeholder | Value |
+|---|---|
+| `base_url` | `https://app.us.honeyhive.ai` (multi-tenant), `https://app.<tenant>.us.honeyhive.ai` (dedicated), or fully custom for self-hosted |
+| `projectId` | The HoneyHive project ID (e.g. `peQ9-_5k2zXezKJ_cwO20KYx`) |
+| `type` | `sessions`, `completions`, or `events` |
+| `eventId` | The `session_id` or `event_id` to open |
+| `dateRange` | Optional. Valid values: `1d`, `3d`, `7d`, `30d`, `90d`, `2w`, `4w`, `8w`, `12w`, `24w`, `3m`, `6m`, `12m`, `AllTime` |
+
+**Type selection:**
+- `sessions` — top-level session traces (most common)
+- `completions` — individual LLM model calls
+- `events` — all event types (tool calls, chains, generic spans)
+
+**Examples:**
+```
+https://app.us.honeyhive.ai/p/peQ9-_5k2zXezKJ_cwO20KYx/traces/sessions?event=23e7b0cb-34cd-4bd6-859a-5b89156f2cc2&range=7d
+https://app.us.honeyhive.ai/p/peQ9-_5k2zXezKJ_cwO20KYx/traces/completions?event=a1b2c3d4-5678-9012-abcd-ef1234567890
+```
+
+If `dateRange` is omitted, the frontend defaults to `7d`.
+
+## Experiment Run Link
+
+Opens a specific experiment run with its results and evaluator scores.
+
+**Format:**
+```
+{base_url}/p/{projectId}/experiments/runs/{runId}
+```
+
+| Placeholder | Value |
+|---|---|
+| `base_url` | `https://app.us.honeyhive.ai` (multi-tenant), `https://app.<tenant>.us.honeyhive.ai` (dedicated), or fully custom for self-hosted |
+| `projectId` | The HoneyHive project ID |
+| `runId` | The experiment run ID returned by `honeyhive experiments` or `evaluate()` |
+
+**Example:**
+```
+https://app.us.honeyhive.ai/p/peQ9-_5k2zXezKJ_cwO20KYx/experiments/runs/b7f3e2a1-9c84-4d56-a123-456789abcdef
+```
+
+## When to Emit Links
+
+| Trigger | Which link |
+|---|---|
+| After a verification smoke run produces a `session_id` (instrumentation) | Trace link for the verified session |
+| After `evaluate()` or `honeyhive experiments` returns a `run_id` (evaluation) | Experiment run link; optionally trace links for individual datapoints |
+| When presenting a failing session to the user or validating a fix (debugging) | Trace link for the failing/fixed session |
+
+## Constructing the URL Programmatically
+
+```bash
+# Bash one-liner (trace link)
+BASE_URL="https://app.us.honeyhive.ai"  # multi-tenant; use app.<tenant>.us.honeyhive.ai for dedicated
+echo "${BASE_URL}/p/${PROJECT_ID}/traces/sessions?event=${SESSION_ID}&range=7d"
+
+# Bash one-liner (experiment run link)
+echo "${BASE_URL}/p/${PROJECT_ID}/experiments/runs/${RUN_ID}"
+```
+
+```python
+# Python
+base = "https://app.us.honeyhive.ai"  # multi-tenant; use app.<tenant>.us.honeyhive.ai for dedicated
+trace_url = f"{base}/p/{project_id}/traces/sessions?event={session_id}&range=7d"
+run_url = f"{base}/p/{project_id}/experiments/runs/{run_id}"
+```
+
+## Notes
+
+- These URLs use the canonical query-param format for traces. The frontend also supports a legacy path-segment format (`/traces/{type}/{event_id}/{dateRange}`) via backwards-compat redirects, but always prefer the canonical format.
+- `base_url` varies by deployment: `app.us.honeyhive.ai` (multi-tenant), `app.<tenant>.us.honeyhive.ai` (dedicated), or fully custom (self-hosted).
+- Project IDs use the character set `[A-Za-z0-9_-]` and do not need URL encoding.
+- Event/session IDs may contain characters that need encoding; use `encodeURIComponent` (JS) or `urllib.parse.quote` (Python) if constructing from untrusted input.

--- a/.agents/skills/honeyhive-instrument/references/state-spec.md
+++ b/.agents/skills/honeyhive-instrument/references/state-spec.md
@@ -1,0 +1,25 @@
+# State specification
+
+Each phase writes its output to a JSON file under `state/` (relative to the `honeyhive-instrument/` root). These files are the handoff contract between phases — each phase reads its predecessor's state rather than re-detecting.
+
+Schemas are JSON Schema (draft 2020-12) in [`state-specs/`](../state-specs/).
+
+## Files
+
+| State file | Written by | Read by | Schema |
+|---|---|---|---|
+| `state/network-validation.json` | Prerequisite (honeyhive-cli sanity check) | Runtime validation, Phase 1 | [state-specs/network-validation.json](../state-specs/network-validation.json) |
+| `state/runtime-validation.json` | Phase 0 (runtime validation) | Phase 1 setup | [state-specs/runtime-validation.json](../state-specs/runtime-validation.json) |
+| `state/setup-result.json` | Phase 1 (language-specific setup) | Phase 2 verification | [state-specs/setup-result.json](../state-specs/setup-result.json) |
+| `state/trace-grade.json` | Phase 2 (verification) | Stop/continue decision, downstream skills | [state-specs/trace-grade.json](../state-specs/trace-grade.json) |
+
+## Lifecycle
+
+1. Prerequisite writes `state/network-validation.json`. On `"status": "fail"`, skill stops.
+2. Phase 0 reads network-validation, writes `state/runtime-validation.json`. On conflicts, surfaces to user.
+3. Phase 1 reads both Phase 0 state files, writes `state/setup-result.json`.
+4. Phase 2 reads setup-result, writes `state/trace-grade.json`. On `"grade": "pass"`, skill proceeds to stop.
+
+Each file is overwritten on re-run (not appended). The timestamp field tracks currency.
+
+Create the state directory on first write: `mkdir -p state`.

--- a/.agents/skills/honeyhive-instrument/references/ts-setup.md
+++ b/.agents/skills/honeyhive-instrument/references/ts-setup.md
@@ -1,0 +1,130 @@
+# TypeScript setup
+
+For Node / Bun / Deno apps using `@honeyhive/api-client` (the manual session+event API).
+
+Assumes [`network-validation.md`](../../honeyhive-cli/references/network-validation.md) has confirmed reachability and [`runtime-validation.md`](runtime-validation.md) has produced findings (`framework`, `existing_hh_wiring`, `existing_otel_provider`, `runtime_version`). This file consumes those findings rather than re-detecting.
+
+> **Mental model: TS instrumentation should feel like the user added a structured logger.** A small, module-level wrapper that's easy to import from any route or service, takes the relevant correlation GUID at session start, and structures its event payloads around OpenTelemetry gen_ai semconv so existing dashboards and the success-criteria rubric grade well without per-call thinking.
+
+There is no first-party TS auto-instrumentor today. The skill's job is to author the wrapper for the user (or adapt their existing logger surface) and place its calls correctly across the request lifecycle.
+
+## Reference docs
+
+- [TypeScript SDK](https://docs.honeyhive.ai/v2/sdk-reference/typescript-sdk-ref)
+- [Semantic-convention reference](https://docs.honeyhive.ai/v2/sdk-reference/semconv-reference)
+- [Framework attribute mapping](https://docs.honeyhive.ai/v2/sdk-reference/semconv-alignment)
+
+## Step 0 — Translate runtime-validation findings into a setup plan
+
+Inputs (from [`runtime-validation.md`](runtime-validation.md) output):
+
+- `runtime_version` (Node 18 / 20 / 22, Bun, Deno)
+- `framework` (the LLM SDK pinned in `package.json` — `openai`, `@anthropic-ai/sdk`, `@langchain/*`, etc.)
+- `existing_hh_wiring` (file:line, or `none`)
+- `existing_otel_provider` (`none` / `proxy-noop` / `real:<vendor>` / `real:custom-mutating`)
+
+Decisions:
+
+| Finding | Action |
+|---|---|
+| `existing_hh_wiring != none` | **Reuse the existing `Client` instance.** Don't construct a second one. Place the logger wrapper around the existing client; the rest of setup adds `startSession` / `event` calls. |
+| `@honeyhive/api-client` missing from `package.json` | Install explicitly (`pnpm add @honeyhive/api-client` / `npm i @honeyhive/api-client`). Do not silently mutate a manifest the user did not commit. |
+| `runtime_version < node-18` | Surface as a finding. `AsyncLocalStorage` works from Node 16+ but `crypto.randomUUID()` and several runtime APIs the wrapper relies on need Node 18+. Recommend an upgrade rather than working around. |
+| Bun / Deno | Both support `AsyncLocalStorage` (via Node compatibility) — the wrapper pattern works as-is. Confirm `process.env` is the env-var source the user's runtime uses (vs `Deno.env`). |
+| `existing_otel_provider = real:<vendor>` | Inform the user that the TS path runs through `@honeyhive/api-client` (manual events) rather than OTel, so HoneyHive doesn't share a TracerProvider with their other vendor. Both pipelines coexist trivially. |
+
+**Never bump framework versions** to make instrumentation work; surface the incompatibility instead.
+
+## Step 1 — Author the logger wrapper (once, module-level)
+
+A single `Client` instance from `@honeyhive/api-client`, instantiated at module load with `apiKey` + `project` from `process.env`. Wrap it in a small helper exposing a logger-shaped surface:
+
+```ts
+// trace.ts (or src/instrumentation/trace.ts)
+import { Client } from "@honeyhive/api-client";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const client = new Client({
+  apiKey: process.env.HH_API_KEY!,
+  dataPlaneUrl: process.env.HH_DATA_PLANE_URL, // dedicated/self-host: set explicitly
+});
+
+const sessionContext = new AsyncLocalStorage<{ sessionId: string }>();
+
+export const logger = {
+  startSession: async (guid: string, name: string, inputs?: unknown) => { /* ... */ },
+  event: async (eventName: string, payload: SemconvEventPayload) => { /* reads sessionId from sessionContext */ },
+  withSession: async <T>(guid: string, name: string, fn: () => Promise<T>) => { /* runs fn inside sessionContext.run */ },
+};
+```
+
+Three properties make this feel like a logger and not an SDK:
+
+1. **Module-level singleton.** Imported wherever needed (`import { logger } from "./trace"`); no per-route construction.
+2. **Async-context-aware.** `AsyncLocalStorage` (or equivalent) carries the active session id across `await` boundaries so handlers downstream of a route don't need to receive `sessionId` as a function argument.
+3. **Semconv-shaped event payloads** (see Step 3) so the call site reads like structured logging, not OTel SDK ceremony.
+
+## Step 2 — Place `startSession` at the request/job boundary; events at each model call
+
+Same idea as Python's `tracer.create_session`: open a session per logical unit of work.
+
+| App shape | Where to call `logger.startSession` (or `withSession`) |
+|---|---|
+| **Express / Koa / Hapi** | Route-scoped middleware that wraps the handler in `logger.withSession(guid, name, () => next())`. |
+| **Next.js / Remix** | At the top of each route handler / `loader` / `action`. |
+| **Fastify** | A `preHandler` hook that runs `withSession`. |
+| **Cloudflare Workers / Vercel Edge** | At the top of `fetch(request)`. |
+| **AWS Lambda** | At the top of the handler — and `await` everything before returning so spans flush before SIGKILL. (See [`prod-gotchas.md`](prod-gotchas.md) §6.) |
+| **BullMQ / RabbitMQ / SQS workers** | At the start of each `process(job)` callback. |
+| **Long-lived chat session** | When the conversation starts; cache the session id in the conversation state so follow-up turns reuse it. |
+
+The GUID passed to `startSession` should come from whatever correlation id the user's app already propagates (`X-Request-Id`, conversation id, job id). If the GUID isn't UUID-shaped, convert deterministically (`uuidv5(NAMESPACE_URL, rawGuid)`) so the same input always becomes the same session id — same trick as Python's GUID shortcut. Avoids needing to set up baggage / W3C tracecontext propagators.
+
+If the user has no propagated GUID, the wrapper should default to `crypto.randomUUID()`.
+
+## Step 3 — Structure event payloads around gen_ai semconv
+
+The wrapper's `event(name, payload)` shape is a thin translation to `client.events.createEvent`. Make the payload shape **mirror OpenTelemetry gen_ai semantic conventions** so semconv-keyed dashboards and the [`success.md`](../success.md) rubric (clean inputs/outputs on core events, full message history visible) grade well by default:
+
+```ts
+await logger.event("openai.chat.completions", {
+  gen_ai: {
+    system: "openai",
+    request: {
+      model: "gpt-4o-mini",
+      temperature: 0.2,
+      max_tokens: 1024,
+    },
+    usage: {
+      input_tokens: response.usage.prompt_tokens,
+      output_tokens: response.usage.completion_tokens,
+    },
+    response: { model: response.model, id: response.id },
+  },
+  inputs: { messages, tools },          // full message history + tool list
+  outputs: { content, tool_calls },     // full response payload
+  metadata: { request_path: req.path },
+});
+```
+
+The wrapper flattens `gen_ai.*` into the event metadata HoneyHive stores so semconv-keyed views and any third-party `gen_ai`-aware tools work without separate shaping.
+
+For tool calls and agent steps, follow the same shape with appropriate `event_type` (`"tool"`, `"chain"`, `"model"`):
+
+```ts
+await logger.event("calculator.evaluate", { inputs: { expression }, outputs: { result }, event_type: "tool" });
+```
+
+## Step 4 — Verify
+
+Before declaring success, confirm:
+
+- Exactly **one** `Client` from `@honeyhive/api-client` instantiated at module load.
+- `apiKey` from `process.env.HH_API_KEY`, never a literal. For dedicated/self-host, `dataPlaneUrl` from `process.env.HH_DATA_PLANE_URL` per [`dedicated-deployments.md`](../../honeyhive-cli/references/dedicated-deployments.md).
+- `logger.startSession(...)` (or `withSession`) is invoked at every session boundary in Step 2's table — the skill should be able to point at the exact files/lines.
+- `logger.event(...)` is called for every LLM call, tool call, and meaningful agent step — payloads structured per Step 3.
+- Async-context store (`AsyncLocalStorage` or framework-equivalent) propagates the session id across `await` boundaries; no `sessionId` argument has been threaded through user functions.
+- The logger import works cleanly from every route/service in the relevant subtree; the skill should be able to grep for `import { logger }` and confirm coverage.
+- Run a smoke test on one route with a real LLM call. Inspect the trace against [`success.md`](../success.md): is the user's original query identifiable? Do LLM events show full message history + tools + response? Are agent/tool nested under their parent agent event?
+
+If the smoke trace shows orphan events, missing message history, or unclear input-output shapes — the wrapper is mechanically correct but the payload structure or session-boundary placement is wrong. Adjust before handing off.

--- a/.agents/skills/honeyhive-instrument/state-specs/network-validation.json
+++ b/.agents/skills/honeyhive-instrument/state-specs/network-validation.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "honeyhive-instrument/state-specs/network-validation.json",
+  "title": "NetworkValidationState",
+  "description": "Output of the honeyhive-cli sanity check / network validation. Written to state/network-validation.json. Read by runtime validation and Phase 1 setup.",
+  "type": "object",
+  "required": ["status", "hh_api_key_source", "hh_data_plane_url", "deployment_type", "probe_method", "validated_at"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail"],
+      "description": "pass if reachability succeeded, fail otherwise. Downstream phases refuse to run on fail."
+    },
+    "hh_api_key_source": {
+      "type": "string",
+      "enum": ["env", "config_file"],
+      "description": "Where the key was found — env (environment variable) or config_file (~/.honeyhive/config.json)."
+    },
+    "hh_data_plane_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "The validated deployment URL."
+    },
+    "deployment_type": {
+      "type": "string",
+      "enum": ["multi-tenant", "dedicated", "self-host"],
+      "description": "Inferred from the URL pattern. Feeds dedicated-deployments.md logic."
+    },
+    "probe_method": {
+      "type": "string",
+      "enum": ["cli", "curl"],
+      "description": "Whether the check used the CLI or curl fallback."
+    },
+    "probe_http_status": {
+      "type": ["integer", "null"],
+      "description": "HTTP status code from the curl probe. Null when CLI was used."
+    },
+    "tls_error": {
+      "type": ["string", "null"],
+      "description": "SSL/TLS error string, if any. Null on success."
+    },
+    "failure_reason": {
+      "type": ["string", "null"],
+      "description": "Human-readable reason for failure. Null on success."
+    },
+    "validated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when validation ran."
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agents/skills/honeyhive-instrument/state-specs/runtime-validation.json
+++ b/.agents/skills/honeyhive-instrument/state-specs/runtime-validation.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "honeyhive-instrument/state-specs/runtime-validation.json",
+  "title": "RuntimeValidationState",
+  "description": "Output of Phase 0 runtime validation. Written to state/runtime-validation.json. Read by Phase 1 setup files.",
+  "type": "object",
+  "required": ["subtree", "language", "runtime_version", "framework", "instrumentor_family", "existing_hh_wiring", "existing_otel_provider", "conflicts", "validated_at"],
+  "properties": {
+    "subtree": {
+      "type": "string",
+      "description": "Relative path to the app subtree ('.' if root)."
+    },
+    "entrypoint": {
+      "type": "string",
+      "description": "Relative path to the main execution entry-point file (e.g. src/main.py, src/index.ts, cmd/server/main.go). Phase 1 uses this to place tracer init and session boundaries."
+    },
+    "language": {
+      "type": "string",
+      "enum": ["python", "typescript", "go", "rust", "java", "dotnet", "other"],
+      "description": "Detected language."
+    },
+    "runtime_version": {
+      "type": "string",
+      "description": "Language + version string (e.g. python-3.11, node-20)."
+    },
+    "framework": {
+      "type": "string",
+      "description": "Detected LLM/agent framework, or 'native' if none."
+    },
+    "framework_version": {
+      "type": ["string", "null"],
+      "description": "Pinned version from manifest. Null if not detected."
+    },
+    "instrumentor_family": {
+      "type": "string",
+      "enum": ["openinference", "traceloop", "none", "conflict"],
+      "description": "Detected instrumentor family."
+    },
+    "existing_hh_wiring": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "line", "type"],
+        "properties": {
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "type": { "type": "string", "description": "e.g. HoneyHiveTracer.init, new Client" }
+        },
+        "additionalProperties": false
+      },
+      "description": "Existing HoneyHive init calls. Empty array if none."
+    },
+    "existing_otel_provider": {
+      "type": "string",
+      "description": "Provider state: none, proxy-noop, real:<vendor>, or real:custom-mutating."
+    },
+    "existing_provider_ref": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["file", "line"],
+          "properties": {
+            "file": { "type": "string" },
+            "line": { "type": "integer" }
+          },
+          "additionalProperties": false
+        },
+        { "type": "null" }
+      ],
+      "description": "File and line of the provider registration. Null if none/proxy."
+    },
+    "conflicts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Detected conflicts (dual instrumentors, multiple tracers, etc.). Empty if clean."
+    },
+    "validated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp."
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agents/skills/honeyhive-instrument/state-specs/setup-result.json
+++ b/.agents/skills/honeyhive-instrument/state-specs/setup-result.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "honeyhive-instrument/state-specs/setup-result.json",
+  "title": "SetupResultState",
+  "description": "Output of Phase 1 setup. Written to state/setup-result.json. Read by Phase 2 verification.",
+  "type": "object",
+  "required": ["setup_path", "dependencies_added", "files_modified", "session_boundary", "dual_export", "co_existence_decision", "setup_at"],
+  "properties": {
+    "setup_path": {
+      "type": "string",
+      "enum": ["A-python", "B-typescript", "C-native-otel"],
+      "description": "Which Phase 1 path was taken."
+    },
+    "dependencies_added": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Packages added. Empty if none."
+    },
+    "files_modified": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "action", "description"],
+        "properties": {
+          "file": { "type": "string" },
+          "action": { "type": "string", "enum": ["created", "modified"] },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "description": "What was changed, with action and one-line description."
+    },
+    "session_boundary": {
+      "type": "object",
+      "required": ["file", "line", "method"],
+      "properties": {
+        "file": { "type": "string" },
+        "line": { "type": "integer" },
+        "method": { "type": "string", "description": "e.g. tracer.create_session" }
+      },
+      "additionalProperties": false,
+      "description": "Where session start was placed."
+    },
+    "dual_export": {
+      "type": "boolean",
+      "description": "Whether dual-export was wired."
+    },
+    "co_existence_decision": {
+      "type": "string",
+      "enum": ["independent", "dual-processor", "rest-api-fallback", "none"],
+      "description": "Which co-existence path was taken. 'none' if no pre-existing provider."
+    },
+    "setup_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp."
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agents/skills/honeyhive-instrument/state-specs/trace-grade.json
+++ b/.agents/skills/honeyhive-instrument/state-specs/trace-grade.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "honeyhive-instrument/state-specs/trace-grade.json",
+  "title": "TraceGradeState",
+  "description": "Output of Phase 2 verification. Written to state/trace-grade.json. Read by the agent for stop/continue decision and by downstream skills.",
+  "type": "object",
+  "required": ["session_id", "trace_link", "event_counts", "errored_events", "deepest_llm_depth", "grade", "grade_notes", "graded_at"],
+  "properties": {
+    "session_id": {
+      "type": "string",
+      "description": "The session from the smoke run."
+    },
+    "trace_link": {
+      "type": "string",
+      "format": "uri",
+      "description": "Shareable UI link (from references/shareable-links.md)."
+    },
+    "event_counts": {
+      "type": "object",
+      "required": ["total", "model", "tool", "chain", "generic"],
+      "properties": {
+        "total": { "type": "integer" },
+        "model": { "type": "integer" },
+        "tool": { "type": "integer" },
+        "chain": { "type": "integer" },
+        "generic": { "type": "integer" }
+      },
+      "additionalProperties": false,
+      "description": "Breakdown by event type."
+    },
+    "errored_events": {
+      "type": "integer",
+      "description": "Count of events with non-null error field."
+    },
+    "deepest_llm_depth": {
+      "type": "integer",
+      "description": "Nesting depth of the deepest model event. <=2 good; >4 means LLM calls are deeply hidden."
+    },
+    "grade": {
+      "type": "string",
+      "enum": ["pass", "fail", "partial"],
+      "description": "pass = proceed to Phase 3, fail = circle back, partial = surface issues to user."
+    },
+    "grade_notes": {
+      "type": "string",
+      "description": "One-line summary of the qualitative assessment."
+    },
+    "failure_reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Specific issues found. Empty on pass."
+    },
+    "graded_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp."
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agents/skills/honeyhive-instrument/success.md
+++ b/.agents/skills/honeyhive-instrument/success.md
@@ -1,0 +1,34 @@
+# Instrumentation success criteria
+
+Phase 2 of [`SKILL.md`](SKILL.md) has two steps: (1) a mechanical smoke run that confirms the process exits clean and a session lands at HoneyHive, then (2) **grading the resulting trace against this rubric**. A mechanically-correct integration that produces a messy trace is not done. This page is what step 2 grades against — what a well-instrumented trace should actually look like once spans are flowing.
+
+A well-instrumented trace has:
+
+## An easy-to-debug trace structure
+
+- Event names are meaningful and easy to navigate — agent names, tool names are present in the event name itself.
+- The order in which the events show up follows time-based order.
+- An agent's LLM calls & tool calls are nested within a clear agent event.
+- LLM calls are easy to find & not deeply hidden.
+- Event types are colored in an easy-to-understand way.
+- Any agent-to-agent interactions have a clear handoff / tool event.
+- Tool calls aren't nested weirdly & are easy to link to the originating LLM / agent call.
+
+## A clean input-output state on core events
+
+- Core orchestration events clearly show what was accepted and what was returned.
+- User's original query & follow-up queries are easy to identify.
+- LLM calls show the full message history, tool list & response cleanly.
+- Tool calls show what the LLM's inputs were & the final tool response returned.
+- Agent invocation shows what the query was and the final plan / trajectory it took.
+- Agent handoff events clearly show what context was passed ahead.
+
+## Visible semantic failures
+
+- Any problematic steps in a long-running agent / RAG are highlighted.
+- Any guardrail triggers are identified easily.
+- Any human interventions are identified easily.
+
+## An end-to-end session summary
+
+- There exists some event in the trace (the final LLM call, etc.) that has a sufficiently good summary of the whole trace to set up end-to-end evaluators against.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "skills": {
+    "honeyhive-alert-root-cause": {
+      "source": "honeyhiveai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/honeyhive-alert-root-cause/SKILL.md",
+      "computedHash": "5e8e10bec968c771cf17d94caaccddc7b80c732425280647c827b4dbf114dfae"
+    },
+    "honeyhive-cli": {
+      "source": "honeyhiveai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/honeyhive-cli/SKILL.md",
+      "computedHash": "57e21332c83cbec66804badbcd3904c19209e0afc64c73a62ae35f464168da25"
+    },
+    "honeyhive-evaluate": {
+      "source": "honeyhiveai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/honeyhive-evaluate/SKILL.md",
+      "computedHash": "266a1f55200d1310d5582c676c3e8ab87ac7b4330c12db33936f1c70d571f377"
+    },
+    "honeyhive-improve": {
+      "source": "honeyhiveai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/honeyhive-improve/SKILL.md",
+      "computedHash": "d4003b0a3aad040644bde1c25d4e364f5c61cd4d610d2c9ebc81285379672445"
+    },
+    "honeyhive-instrument": {
+      "source": "honeyhiveai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/honeyhive-instrument/SKILL.md",
+      "computedHash": "04b29460fccc303c71cd927baaa2cbfd91d406080c4cf0e2ada107921c5c3b67"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installs HoneyHive's official **Agent Skills** into the repo so coding agents (Cursor, Claude Code, Copilot, etc.) get reusable HoneyHive workflows, per the [HoneyHive docs](https://docs.honeyhive.ai/v2/introduction/ai-coding-agents).

Installed non-interactively with:

```bash
npx skills add honeyhiveai/skills --skill '*' -y
```

This adds all 5 current skills under `.agents/skills/` (+ a `skills-lock.json` pinning each by content hash):

- `honeyhive-instrument` — add HoneyHive/OpenTelemetry tracing to an LLM/agent/RAG app
- `honeyhive-evaluate` — set up experiments, datasets, and evaluators
- `honeyhive-improve` — debug & improve an agent from trace data
- `honeyhive-cli` — CLI install/usage reference (shared by the others)
- `honeyhive-alert-root-cause` — triage flagged sessions and recommend guardrails

## Notes

- ~212K, 22 files; skills run with full agent permissions — review before use.
- The HoneyHive **Docs MCP server** (`honeyhive-docs` → `https://docs.honeyhive.ai/mcp`) is already configured in `.cursor/mcp.json` on `main`, so it is not part of this PR.
- Split out from the ACS cookbook PR (#50) so the cookbook and the repo-wide agent tooling can be reviewed/merged independently.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cf1e655-272e-406f-8df3-3650fe7bedd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cf1e655-272e-406f-8df3-3650fe7bedd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

