### PR TITLE
Set up Cloud Agent dev environment for HoneyHive cookbooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a monorepo of **independent HoneyHive integration cookbooks**. Each top-level
+directory is a standalone example with its own README, its own dependency set, and (for Python)
+its own virtual environment. There is no shared/root package, no test suite, and no lint config.
+Always work inside the specific cookbook directory you care about.
+
+### Toolchain / how deps are installed
+- Python deps use **uv** (installed to `~/.local/bin`; `~/.bashrc` already adds it to PATH for
+  interactive shells). In a non-interactive context use the absolute path `~/.local/bin/uv`.
+- The startup update script creates a **per-cookbook `.venv`** for each Python cookbook and runs
+  `pnpm install` for the one TypeScript cookbook. Do not create a single shared venv: the
+  cookbooks pin conflicting dependency versions.
+- Run a Python cookbook from inside its directory so `uv run` auto-detects its `.venv`, e.g.
+  `cd openai-honeyhive-cookbook && uv run python basic_chat.py`. Standard run commands live in
+  each cookbook's README.
+- `honeyhive-skills-strands` is managed with `pyproject.toml` + `uv.lock` (use `uv sync`), not a
+  plain `requirements.txt` venv.
+
+### Credentials available in this environment (as secrets/env vars)
+`HH_API_KEY`, `HH_API_URL`, `HH_PROJECT`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`.
+The HoneyHive SDK reads `HH_API_KEY` / `HH_API_URL` / `HH_PROJECT` from the environment, so no
+`.env` file is needed for the runnable cookbooks below.
+
+### What can actually be run end-to-end here
+- `openai-honeyhive-cookbook` — needs HoneyHive + OpenAI. Runnable.
+- `google-adk-cookbook` — needs HoneyHive + Google/Gemini. Runnable (`uv run python main.py --version v2`).
+- `honeyhive-skills-strands` — needs HoneyHive + OpenAI. Runnable (`uv run python agent.py "..."`).
+
+### Blocked cookbooks (deps still install for editing, but they cannot run here)
+- AWS Bedrock creds missing: `aws-bedrock-honeyhive-cookbook`, `claims-summarizer-python`,
+  `strands-agentcore-cookbook` (also needs the AgentCore runtime/CLI + AWS infra).
+- Azure OpenAI deployment missing: `azure-openai-honeyhive-cookbook`,
+  `legacy_cookbooks/claims-transcript-summarizer-js`.
+- `cursor-sdk-honeyhive` (TypeScript): needs `CURSOR_API_KEY` at runtime. `pnpm build` and
+  `pnpm typecheck` still work without it.
+- `qdrant-cookbook`: creds are covered (HoneyHive + OpenAI) but it expects a **live Qdrant server**
+  at `QDRANT_URL` (default `http://localhost:6333`); start one (e.g. Docker) or switch the client
+  to in-memory mode before running.
+- `wealth-management-agent`: **excluded from the update script** because its pinned `crewai`
+  requires `opentelemetry-sdk<1.35` while `honeyhive>=1.0.0` requires `>=1.41.0`, so its
+  `requirements.txt` is currently unresolvable (independent of the also-missing `SERPAPI_KEY`).
+
+### Non-obvious gotchas
+- `google-adk-cookbook/main.py` prints a benign `Failed to detach context` OpenTelemetry
+  traceback on stderr during async teardown. It is harmless: the process exits 0 and the full
+  agent response + `Session ID` are printed. Do not try to "fix" it.
+- To confirm traces actually reached HoneyHive, query by the printed session id:
+  `hh.events.get_by_session_id(session_id, project=os.getenv("HH_PROJECT"))` using
+  `from honeyhive import HoneyHive` (constructed with `api_key=` and `server_url=`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this HoneyHive cookbooks monorepo and documents durable, non-obvious setup guidance for future agents. No cookbook code was modified.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the per-cookbook venv model, `uv` usage, which cookbooks are runnable vs blocked (and why), and known gotchas.
- The environment update script (configured out-of-repo) installs `uv`, creates a per-cookbook Python `.venv` and installs each cookbook's `requirements.txt`, runs `uv sync` for `honeyhive-skills-strands`, and `pnpm install` for `cursor-sdk-honeyhive`.

## Environment

- Python 3.12 + `uv` 0.12.x, Node 22 + pnpm 10.
- Available credentials: `HH_API_KEY`, `HH_API_URL`, `HH_PROJECT`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`.

## Verified working (hello-world)

Ran three cookbooks end-to-end against live APIs and confirmed traces reached HoneyHive:

- `openai-honeyhive-cookbook` → `uv run python basic_chat.py` (real OpenAI response).
- `honeyhive-skills-strands` → `uv run python agent.py "What is 17 * 23?"` (tool-using agent, answer 391).
- `google-adk-cookbook` → `uv run python main.py --version v2` (multi-agent Gemini flow). Verified **12 events ingested** into HoneyHive via `hh.events.get_by_session_id(...)`.
- `cursor-sdk-honeyhive` → `pnpm typecheck` and `pnpm build` pass (runtime needs `CURSOR_API_KEY`).

## Blocked cookbooks

`aws-bedrock-honeyhive-cookbook`, `claims-summarizer-python`, `strands-agentcore-cookbook` (AWS), `azure-openai-honeyhive-cookbook` (Azure), `cursor-sdk-honeyhive` (Cursor key), and `wealth-management-agent` (missing `SERPAPI_KEY` plus a genuine `crewai`/`honeyhive` opentelemetry version conflict, so it is excluded from the update script). Their deps still install for editing where resolvable.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feebb27e-6424-4930-9382-703535ed961f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feebb27e-6424-4930-9382-703535ed961f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

